### PR TITLE
k8s 1.13.5 bug fix

### DIFF
--- a/deploy/nacos/nacos-quick-start.yaml
+++ b/deploy/nacos/nacos-quick-start.yaml
@@ -10,6 +10,7 @@ spec:
     - port: 8848
       name: server
       targetPort: 8848
+  clusterIP: None
   selector:
     app: nacos
 ---


### PR DESCRIPTION
k8s 1.13.5,need config that is `clusterIP: None`.
otherelse pods couldn't ping the others node by dns ,and cluster couldn't choose the leader.