### PR TITLE
Update plugin.sh

### DIFF
--- a/plugin/peer/plugin.sh
+++ b/plugin/peer/plugin.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 PEER_FINDER_DIR="/home/nacos/plugins/peer-finder"
+cp /etc/hosts ~/hosts.new && sed -i 's/cluster.local./cluster.local/g' ~/hosts.new && cp -f ~/hosts.new /etc/hosts
 cd ${PEER_FINDER_DIR}
 ./peer-finder -on-start=${PEER_FINDER_DIR}/on-start.sh -on-change=${PEER_FINDER_DIR}/on-change.sh -service=${SERVICE_NAME} &


### PR DESCRIPTION
解决 因kubelet 参数  --cluster-domain=cluster.local. 
导致 headless域名 多了一个点 造成  unable to find local peer: nacos-0.nacos-headless.xinyi-dev.svc.cluster.local.:8848, 错误