### PR TITLE
如果没有配置global.storageClass.provisioner，则默认已存在storage class，无需重复创建

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ gen
 !/.idea/
 !/.idea/*
 /nacos-k8s.iml
+
+.DS_Store

--- a/helm/templates/storageclass.yaml
+++ b/helm/templates/storageclass.yaml
@@ -1,10 +1,10 @@
-{{- if and .Values.persistence.enabled .Values.persistence.storageClassName -}}
+{{- if and .Values.persistence.enabled .Values.global.storageClass.provisioner .Values.persistence.storageClassName -}}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
    name: {{ .Values.persistence.storageClassName }}
-provisioner: 
+provisioner:
 {{ toYaml .Values.global.storageClass.provisioner | indent 2 }}
 parameters:
-{{ toYaml .Values.persistence.classParameters | indent 2 }}    
+{{ toYaml .Values.persistence.classParameters | indent 2 }}
 {{- end }}


### PR DESCRIPTION
主要目的是兼容已存在storageClass