### PR TITLE
减少文件修改，避免nacos监听文件变更时可能读取到不正确节点信息

### DIFF
--- a/plugin/peer/on-change.sh
+++ b/plugin/peer/on-change.sh
@@ -7,15 +7,15 @@ while read -ra LINE; do
     PEERS=("${PEERS[@]}" $LINE)
 done
 
-echo "" > "${CLUSTER_CONF}"
-
 if [ ${#PEERS[@]} -eq 1 ]; then
 
     echo "${PEERS[0]}:$NACOS_APPLICATION_PORT" > "${CLUSTER_CONF}"
     exit
 fi
+CONTENT=""
 for peer in "${PEERS[@]}"; do
- echo "${peer}:$NACOS_APPLICATION_PORT" >> "${CLUSTER_CONF}"
+ CONTENT="${CONTENT}${peer}:$NACOS_APPLICATION_PORT\n"
 done
 
-echo "on change write peers:"${PEERS}
+echo -e "${CONTENT%\\n}" > "${CLUSTER_CONF}"
+echo "on change write peers:"${PEERS[@]}


### PR DESCRIPTION
使用 peer-finder  扩容时 发现经常会出现 cluster.conf 仅包含`nacos-0.nacos.nacos.svc.cluster.local:8848
nacos-1.nacos.nacos.svc.cluster.local:8848` 两条记录的情况（比如我3节点扩4节点）。
在nacos 代码FileConfigMemberLookup#readClusterConfFromDisk方法 中增加 日志。打印读取到的文件内容 以及触发次数。
发现读取到的文件内容就是错误的（排除nacos后续回写cluster.conf的情况），且触发多次读取。

故修改on-change.sh确保当前仅会触发两次（1次是peer-plugin修改，1次是nacos 回写配置文件后触发）