### PR TITLE
Update nacos-quick-start.yaml

### DIFF
--- a/deploy/nacos/nacos-quick-start.yaml
+++ b/deploy/nacos/nacos-quick-start.yaml
@@ -106,7 +106,7 @@ spec:
             - name: PREFER_HOST_MODE
               value: "hostname"
             - name: NACOS_SERVERS
-              value: "nacos-0.nacos-headless.default.svc.cluster.local:8848 nacos-1.nacos-headless.default.svc.cluster.local:8848 nacos-2.nacos-headless.default.svc.cluster.local:8848"
+              value: "nacos-0.nacos-headless.default.svc.cluster.local.:8848 nacos-1.nacos-headless.default.svc.cluster.local.:8848 nacos-2.nacos-headless.default.svc.cluster.local.:8848"
   selector:
     matchLabels:
       app: nacos


### PR DESCRIPTION
不使用cluster.local. 创建sts的时候会导致集群节点有四个 nacos-0.nacos-headless.default.svc.cluster.local. nacos-0.nacos-headless.default.svc.cluster.local 会出现这两个，导致集群状态不对


nacos-0.nacos-headless.default.svc.cluster.local.