### PR TITLE
Update configmap.yaml

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -5,9 +5,9 @@ metadata:
   name: nacos-cm
 data:
   {{- with .Values.nacos.storage.db }}
-  mysql.db.host: {{.host}}
+  mysql.db.host: {{ .host }}
   mysql.db.name: {{ .name }}
-  mysql.port: {{ .port | default 3306}}
+  mysql.port: {{ .port | default 3306 | quote }}
   mysql.user: {{ .username }}
   mysql.password: {{ .password }}
   mysql.param: {{ .param | default "characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useSSL=false" }}


### PR DESCRIPTION
update for ConfigMap v1 need string not the number


```
helm.go:81: [debug] ConfigMap in version "v1" cannot be handled as a ConfigMap: v1.ConfigMap.Data: ReadString: expects " or n, but found 3, error found in #10 byte of ...|ql.port":3306,"mysql|..., bigger context ...|SSL=false","mysql.password":"admin","mysql.port":3306,"mysql.user":"admin"},"kind":"ConfigMap","meta|...​
```