### PR TITLE
 fix: mysql.port cannot convert int64 to string

### DIFF
--- a/helm/templates/configmap.yaml
+++ b/helm/templates/configmap.yaml
@@ -7,7 +7,7 @@ data:
   {{- with .Values.nacos.storage.db }}
   mysql.db.host: {{.host}}
   mysql.db.name: {{ .name }}
-  mysql.port: {{ .port | default 3306}}
+  mysql.port: "{{ .port | default 3306}}"
   mysql.user: {{ .username }}
   mysql.password: {{ .password }}
   mysql.param: {{ .param | default "characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useSSL=false" }}


### PR DESCRIPTION
fix mysql.port error.

![image](https://user-images.githubusercontent.com/7947984/148325067-dd76bc43-97ba-40ef-a5aa-814bce7bee02.png)
