### PR TITLE
feat: support operator k8s general-configuration #299

### DIFF
--- a/operator/README-CN.md
+++ b/operator/README-CN.md
@@ -141,6 +141,10 @@ make demo clear=true
 | spec.volume.requests.storage | 存储大小 | 1Gi |
 | spec.volume.storageClass | 存储类 | default |
 | spec.config | 其他自定义配置，自动映射到custom.propretise | 格式和configmap兼容 |
+| spec.k8sWrapper | 支持通用k8配置，即PodSpec对象，会自动覆盖所有内部pod对象 | 无 |
+
+更多配置案例见./config/samples
+
 ### 设置模式
 目前支持standalone和cluster模式
 

--- a/operator/api/v1alpha1/nacos_types.go
+++ b/operator/api/v1alpha1/nacos_types.go
@@ -19,6 +19,7 @@ package v1alpha1
 import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"nacos.io/nacos-operator/pkg/util/merge/api"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -49,8 +50,13 @@ type NacosSpec struct {
 	Volume   Storage  `json:"volume,omitempty"`
 	// 配置文件
 	Config string `json:"config,omitempty"`
+	// 通用k8s配置包装器
+	K8sWrapper k8sWrapper `json:"k8sWrapper,omitempty"`
 }
 
+type k8sWrapper struct {
+	PodSpec api.PodSpecWrapper `json:"PodSpec,omitempty"`
+}
 type Storage struct {
 	Enabled      bool            `json:"enabled,omitempty"`
 	Requests     v1.ResourceList `json:"requests,omitempty" protobuf:"bytes,2,rep,name=requests,casttype=ResourceList,castkey=ResourceName"`

--- a/operator/config/samples/nacos_mysql_wrapper.yaml
+++ b/operator/config/samples/nacos_mysql_wrapper.yaml
@@ -1,0 +1,34 @@
+apiVersion: nacos.io/v1alpha1
+kind: Nacos
+metadata:
+  name: nacos
+spec:
+  # standalone/cluster
+  type: standalone
+  image: nacos/nacos-server:1.4.1
+  replicas: 1
+  resources:
+    requests:
+      cpu: 100m
+      memory: 512Mi
+    limits:
+      cpu: 2
+      memory: 2Gi
+  mysqlInitImage: "registry.cn-hangzhou.aliyuncs.com/choerodon-tools/mysql-client:10.2.15-r0"
+  database:
+    type: mysql
+    mysqlHost: 10.98.20.59
+    mysqlDb: nacos
+    mysqlUser: root
+    mysqlPort: "3306"
+    mysqlPassword: "123456"
+  k8sWrapper:
+    PodSpec:
+      nodeSelector:
+        disktype: ssd
+      tolerations:
+        - key: "example-key"
+          operator: "Exists"
+          effect: "NoSchedule"
+
+

--- a/operator/pkg/service/operator/Kind.go
+++ b/operator/pkg/service/operator/Kind.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	batchv1 "k8s.io/api/batch/v1"
+	"nacos.io/nacos-operator/pkg/util/merge"
 	"path/filepath"
 	"strconv"
 
@@ -143,11 +144,13 @@ func (e *KindClient) ValidationField(nacos *nacosgroupv1alpha1.Nacos) {
 func (e *KindClient) EnsureStatefulsetCluster(nacos *nacosgroupv1alpha1.Nacos) {
 	ss := e.buildStatefulset(nacos)
 	ss = e.buildStatefulsetCluster(nacos, ss)
+	ss.Spec.Template.Spec  = merge.PodSpec(ss.Spec.Template.Spec,nacos.Spec.K8sWrapper.PodSpec.Spec)
 	myErrors.EnsureNormal(e.k8sService.CreateOrUpdateStatefulSet(nacos.Namespace, ss))
 }
 
 func (e *KindClient) EnsureStatefulset(nacos *nacosgroupv1alpha1.Nacos) {
 	ss := e.buildStatefulset(nacos)
+	ss.Spec.Template.Spec  = merge.PodSpec(ss.Spec.Template.Spec,nacos.Spec.K8sWrapper.PodSpec.Spec)
 	myErrors.EnsureNormal(e.k8sService.CreateOrUpdateStatefulSet(nacos.Namespace, ss))
 }
 
@@ -187,6 +190,7 @@ func (e *KindClient) EnsureMysqlConfigMap(nacos *nacosgroupv1alpha1.Nacos) {
 func (e *KindClient) EnsureJob(nacos *nacosgroupv1alpha1.Nacos) {
 	// 使用job执行SQL脚本的逻辑
 	job := e.buildJob(nacos)
+	job.Spec.Template.Spec  = merge.PodSpec(job.Spec.Template.Spec,nacos.Spec.K8sWrapper.PodSpec.Spec)
 	myErrors.EnsureNormal(e.k8sService.CreateIfNotExistsJob(nacos.Namespace, job))
 }
 

--- a/operator/pkg/util/contains/contains.go
+++ b/operator/pkg/util/contains/contains.go
@@ -1,0 +1,33 @@
+package contains
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func String(slice []string, s string) bool {
+	for _, elem := range slice {
+		if elem == s {
+			return true
+		}
+	}
+	return false
+}
+
+func NamespacedName(nsNames []types.NamespacedName, nsName types.NamespacedName) bool {
+	for _, elem := range nsNames {
+		if elem == nsName {
+			return true
+		}
+	}
+	return false
+}
+
+func AccessMode(accessModes []corev1.PersistentVolumeAccessMode, mode corev1.PersistentVolumeAccessMode) bool {
+	for _, elem := range accessModes {
+		if elem == mode {
+			return true
+		}
+	}
+	return false
+}

--- a/operator/pkg/util/merge/api/deployment.go
+++ b/operator/pkg/util/merge/api/deployment.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"encoding/json"
+
+	v1 "k8s.io/api/apps/v1"
+)
+
+// StatefulSetConfiguration holds the optional custom StatefulSet
+// that should be merged into the operator created one.
+type DeploymentConfiguration struct {
+	// +kubebuilder:pruning:PreserveUnknownFields
+	SpecWrapper DeploymentSpecWrapper `json:"spec"`
+}
+
+type DeploymentSpecWrapper struct {
+	Spec v1.DeploymentSpec `json:"-"`
+}
+
+// MarshalJSON defers JSON encoding to the wrapped map
+func (m *DeploymentSpecWrapper) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.Spec)
+}
+
+// UnmarshalJSON will decode the data into the wrapped map
+func (m *DeploymentSpecWrapper) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &m.Spec)
+}
+
+func (m *DeploymentSpecWrapper) DeepCopy() *DeploymentSpecWrapper {
+	return &DeploymentSpecWrapper{
+		Spec: m.Spec,
+	}
+}

--- a/operator/pkg/util/merge/api/pod.go
+++ b/operator/pkg/util/merge/api/pod.go
@@ -1,0 +1,34 @@
+package api
+
+import (
+	"encoding/json"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+// StatefulSetConfiguration holds the optional custom StatefulSet
+// that should be merged into the operator created one.
+type PodConfiguration struct {
+	// +kubebuilder:pruning:PreserveUnknownFields
+	SpecWrapper DeploymentSpecWrapper `json:"spec"`
+}
+
+type PodSpecWrapper struct {
+	Spec v1.PodSpec `json:"-"`
+}
+
+// MarshalJSON defers JSON encoding to the wrapped map
+func (m *PodSpecWrapper) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.Spec)
+}
+
+// UnmarshalJSON will decode the data into the wrapped map
+func (m *PodSpecWrapper) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &m.Spec)
+}
+
+func (m *PodSpecWrapper) DeepCopy() *PodSpecWrapper {
+	return &PodSpecWrapper{
+		Spec: m.Spec,
+	}
+}

--- a/operator/pkg/util/merge/api/statefulset.go
+++ b/operator/pkg/util/merge/api/statefulset.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	v1 "k8s.io/api/apps/v1"
+	"encoding/json"
+)
+
+// StatefulSetConfiguration holds the optional custom StatefulSet
+// that should be merged into the operator created one.
+type StatefulSetConfiguration struct {
+	// +kubebuilder:pruning:PreserveUnknownFields
+	SpecWrapper StatefulSetSpecWrapper `json:"spec"`
+}
+
+type StatefulSetSpecWrapper struct {
+	Spec v1.StatefulSetSpec `json:"-"`
+}
+
+// MarshalJSON defers JSON encoding to the wrapped map
+func (m *StatefulSetSpecWrapper) MarshalJSON() ([]byte, error) {
+	return json.Marshal(m.Spec)
+}
+
+// UnmarshalJSON will decode the data into the wrapped map
+func (m *StatefulSetSpecWrapper) UnmarshalJSON(data []byte) error {
+	return json.Unmarshal(data, &m.Spec)
+}
+
+func (m *StatefulSetSpecWrapper) DeepCopy() *StatefulSetSpecWrapper {
+	return &StatefulSetSpecWrapper{
+		Spec: m.Spec,
+	}
+}

--- a/operator/pkg/util/merge/merge.go
+++ b/operator/pkg/util/merge/merge.go
@@ -1,0 +1,684 @@
+package merge
+
+import (
+	"sort"
+	"strings"
+
+	"nacos.io/nacos-operator/pkg/util/contains"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// StringSlices accepts two slices of strings, and returns a string slice
+// containing the distinct elements present in both.
+func StringSlices(slice1, slice2 []string) []string {
+	mergedStrings := make([]string, 0)
+	mergedStrings = append(mergedStrings, slice1...)
+	for _, s := range slice2 {
+		if !contains.String(mergedStrings, s) {
+			mergedStrings = append(mergedStrings, s)
+		}
+	}
+	return mergedStrings
+}
+
+// StringToStringMap merges two string maps together with the second map
+// overriding any values also specified in the first.
+func StringToStringMap(map1, map2 map[string]string) map[string]string {
+	mergedMap := make(map[string]string)
+	for k, v := range map1 {
+		mergedMap[k] = v
+	}
+	for k, v := range map2 {
+		mergedMap[k] = v
+	}
+	return mergedMap
+}
+
+// StringToBoolMap merges two string-to-bool maps together with the second map
+// overriding any values also specified in the first.
+func StringToBoolMap(map1, map2 map[string]bool) map[string]bool {
+	mergedMap := make(map[string]bool)
+	for k, v := range map1 {
+		mergedMap[k] = v
+	}
+	for k, v := range map2 {
+		mergedMap[k] = v
+	}
+	return mergedMap
+}
+
+// Containers merges two slices of containers merging each item by container name.
+func Containers(defaultContainers, overrideContainers []corev1.Container) []corev1.Container {
+	mergedContainerMap := map[string]corev1.Container{}
+
+	originalMap := createContainerMap(defaultContainers)
+	overrideMap := createContainerMap(overrideContainers)
+
+	for k, v := range originalMap {
+		mergedContainerMap[k] = v
+	}
+
+	for k, v := range overrideMap {
+		if orig, ok := originalMap[k]; ok {
+			mergedContainerMap[k] = Container(orig, v)
+		} else {
+			mergedContainerMap[k] = v
+		}
+	}
+
+	var mergedContainers []corev1.Container
+	for _, v := range mergedContainerMap {
+		mergedContainers = append(mergedContainers, v)
+	}
+
+	sort.SliceStable(mergedContainers, func(i, j int) bool {
+		return mergedContainers[i].Name < mergedContainers[j].Name
+	})
+	return mergedContainers
+
+}
+
+func createContainerMap(containers []corev1.Container) map[string]corev1.Container {
+	m := make(map[string]corev1.Container)
+	for _, v := range containers {
+		m[v.Name] = v
+	}
+	return m
+}
+
+func Container(defaultContainer, overrideContainer corev1.Container) corev1.Container {
+	merged := defaultContainer
+
+	if overrideContainer.Name != "" {
+		merged.Name = overrideContainer.Name
+	}
+
+	if overrideContainer.Image != "" {
+		merged.Image = overrideContainer.Image
+	}
+
+	merged.Command = StringSlices(defaultContainer.Command, overrideContainer.Command)
+	merged.Args = StringSlices(defaultContainer.Args, overrideContainer.Args)
+
+	if overrideContainer.WorkingDir != "" {
+		merged.WorkingDir = overrideContainer.WorkingDir
+	}
+
+	merged.Ports = ContainerPortSlicesByName(defaultContainer.Ports, overrideContainer.Ports)
+	merged.Env = Envs(defaultContainer.Env, overrideContainer.Env)
+	merged.Resources = ResourceRequirements(defaultContainer.Resources, overrideContainer.Resources)
+	merged.VolumeMounts = VolumeMounts(defaultContainer.VolumeMounts, overrideContainer.VolumeMounts)
+	merged.VolumeDevices = VolumeDevices(defaultContainer.VolumeDevices, overrideContainer.VolumeDevices)
+	merged.LivenessProbe = Probe(defaultContainer.LivenessProbe, overrideContainer.LivenessProbe)
+	merged.ReadinessProbe = Probe(defaultContainer.ReadinessProbe, overrideContainer.ReadinessProbe)
+	merged.StartupProbe = Probe(defaultContainer.StartupProbe, overrideContainer.StartupProbe)
+	merged.Lifecycle = LifeCycle(defaultContainer.Lifecycle, overrideContainer.Lifecycle)
+
+	if overrideContainer.TerminationMessagePath != "" {
+		merged.TerminationMessagePath = overrideContainer.TerminationMessagePath
+	}
+
+	if overrideContainer.TerminationMessagePolicy != "" {
+		merged.TerminationMessagePolicy = overrideContainer.TerminationMessagePolicy
+	}
+
+	if overrideContainer.ImagePullPolicy != "" {
+		merged.ImagePullPolicy = overrideContainer.ImagePullPolicy
+	}
+
+	merged.SecurityContext = SecurityContext(defaultContainer.SecurityContext, overrideContainer.SecurityContext)
+
+	if overrideContainer.Stdin {
+		merged.Stdin = overrideContainer.Stdin
+	}
+
+	if overrideContainer.StdinOnce {
+		merged.StdinOnce = overrideContainer.StdinOnce
+	}
+
+	if overrideContainer.TTY {
+		merged.TTY = overrideContainer.TTY
+	}
+
+	return merged
+}
+
+// Probe merges the contents of two probes together.
+func Probe(original, override *corev1.Probe) *corev1.Probe {
+	if override == nil {
+		return original
+	}
+	if original == nil {
+		return override
+	}
+	merged := *original
+	if override.Handler.Exec != nil {
+		merged.Handler.Exec = override.Handler.Exec
+	}
+	if override.Handler.HTTPGet != nil {
+		merged.Handler.HTTPGet = override.Handler.HTTPGet
+	}
+	if override.Handler.TCPSocket != nil {
+		merged.Handler.TCPSocket = override.Handler.TCPSocket
+	}
+	if override.InitialDelaySeconds != 0 {
+		merged.InitialDelaySeconds = override.InitialDelaySeconds
+	}
+	if override.TimeoutSeconds != 0 {
+		merged.TimeoutSeconds = override.TimeoutSeconds
+	}
+	if override.PeriodSeconds != 0 {
+		merged.PeriodSeconds = override.PeriodSeconds
+	}
+
+	if override.SuccessThreshold != 0 {
+		merged.SuccessThreshold = override.SuccessThreshold
+	}
+
+	if override.FailureThreshold != 0 {
+		merged.FailureThreshold = override.FailureThreshold
+	}
+	return &merged
+}
+
+// LifeCycle merges two LifeCycles.
+func LifeCycle(original, override *corev1.Lifecycle) *corev1.Lifecycle {
+	if override == nil {
+		return original
+	}
+	if original == nil {
+		return override
+	}
+	merged := *original
+
+	if override.PostStart != nil {
+		merged.PostStart = override.PostStart
+	}
+	if override.PreStop != nil {
+		merged.PreStop = override.PreStop
+	}
+	return &merged
+}
+
+// SecurityContext merges two security contexts.
+func SecurityContext(original, override *corev1.SecurityContext) *corev1.SecurityContext {
+	if override == nil {
+		return original
+	}
+	if original == nil {
+		return override
+	}
+	merged := *original
+
+	if override.Capabilities != nil {
+		merged.Capabilities = override.Capabilities
+	}
+
+	if override.Privileged != nil {
+		merged.Privileged = override.Privileged
+	}
+
+	if override.SELinuxOptions != nil {
+		merged.SELinuxOptions = override.SELinuxOptions
+	}
+
+	if override.WindowsOptions != nil {
+		merged.WindowsOptions = override.WindowsOptions
+	}
+	if override.RunAsUser != nil {
+		merged.RunAsUser = override.RunAsUser
+	}
+	if override.RunAsGroup != nil {
+		merged.RunAsGroup = override.RunAsGroup
+	}
+	if override.RunAsNonRoot != nil {
+		merged.RunAsNonRoot = override.RunAsNonRoot
+	}
+	if override.ReadOnlyRootFilesystem != nil {
+		merged.ReadOnlyRootFilesystem = override.ReadOnlyRootFilesystem
+	}
+	if override.AllowPrivilegeEscalation != nil {
+		merged.AllowPrivilegeEscalation = override.AllowPrivilegeEscalation
+	}
+	if override.ProcMount != nil {
+		merged.ProcMount = override.ProcMount
+	}
+	return &merged
+}
+
+// VolumeDevices merges two slices of VolumeDevices by name.
+func VolumeDevices(original, override []corev1.VolumeDevice) []corev1.VolumeDevice {
+	mergedDevicesMap := map[string]corev1.VolumeDevice{}
+	originalDevicesMap := createVolumeDevicesMap(original)
+	overrideDevicesMap := createVolumeDevicesMap(override)
+
+	for k, v := range originalDevicesMap {
+		mergedDevicesMap[k] = v
+	}
+
+	for k, v := range overrideDevicesMap {
+		if orig, ok := originalDevicesMap[k]; ok {
+			mergedDevicesMap[k] = mergeVolumeDevice(orig, v)
+		} else {
+			mergedDevicesMap[k] = v
+		}
+	}
+
+	var mergedDevices []corev1.VolumeDevice
+	for _, v := range mergedDevicesMap {
+		mergedDevices = append(mergedDevices, v)
+	}
+
+	sort.SliceStable(mergedDevices, func(i, j int) bool {
+		return mergedDevices[i].Name < mergedDevices[j].Name
+	})
+	return mergedDevices
+}
+
+func createVolumeDevicesMap(devices []corev1.VolumeDevice) map[string]corev1.VolumeDevice {
+	m := make(map[string]corev1.VolumeDevice)
+	for _, v := range devices {
+		m[v.Name] = v
+	}
+	return m
+}
+
+func mergeVolumeDevice(original, override corev1.VolumeDevice) corev1.VolumeDevice {
+	merged := original
+	if override.Name != "" {
+		merged.Name = override.Name
+	}
+	if override.DevicePath != "" {
+		merged.DevicePath = override.DevicePath
+	}
+	return merged
+}
+
+// Envs merges two slices of EnvVars using their name as the unique
+// identifier.
+func Envs(original, override []corev1.EnvVar) []corev1.EnvVar {
+	mergedEnvsMap := map[string]corev1.EnvVar{}
+
+	originalMap := createEnvMap(original)
+	overrideMap := createEnvMap(override)
+
+	for k, v := range originalMap {
+		mergedEnvsMap[k] = v
+	}
+
+	for k, v := range overrideMap {
+		if orig, ok := originalMap[k]; ok {
+			mergedEnvsMap[k] = mergeSingleEnv(orig, v)
+		} else {
+			mergedEnvsMap[k] = v
+		}
+	}
+
+	var mergedEnvs []corev1.EnvVar
+	for _, v := range mergedEnvsMap {
+		mergedEnvs = append(mergedEnvs, v)
+	}
+
+	sort.SliceStable(mergedEnvs, func(i, j int) bool {
+		return mergedEnvs[i].Name < mergedEnvs[j].Name
+	})
+	return mergedEnvs
+}
+
+func mergeSingleEnv(original, override corev1.EnvVar) corev1.EnvVar {
+	merged := original
+	if override.Value != "" {
+		merged.Value = override.Value
+		merged.ValueFrom = nil
+	}
+
+	if override.ValueFrom != nil {
+		merged.ValueFrom = override.ValueFrom
+		merged.Value = ""
+	}
+	return merged
+}
+
+func createEnvMap(env []corev1.EnvVar) map[string]corev1.EnvVar {
+	m := make(map[string]corev1.EnvVar)
+	for _, e := range env {
+		m[e.Name] = e
+	}
+	return m
+}
+
+// ResourceRequirements merges two resource requirements.
+func ResourceRequirements(original, override corev1.ResourceRequirements) corev1.ResourceRequirements {
+	merged := original
+	if override.Limits != nil {
+		merged.Limits = override.Limits
+	}
+
+	if override.Requests != nil {
+		merged.Requests = override.Requests
+	}
+	return merged
+}
+
+// ContainerPorts merges all of the fields of the overridePort on top of the defaultPort
+// if the fields don't have a zero value. Thw new ContainerPort is returned.
+func ContainerPorts(defaultPort, overridePort corev1.ContainerPort) corev1.ContainerPort {
+	mergedPort := defaultPort
+	if overridePort.Name != "" {
+		mergedPort.Name = overridePort.Name
+	}
+	if overridePort.ContainerPort != 0 {
+		mergedPort.ContainerPort = overridePort.ContainerPort
+	}
+	if overridePort.HostPort != 0 {
+		mergedPort.HostPort = overridePort.HostPort
+	}
+	if overridePort.Protocol != "" {
+		mergedPort.Protocol = overridePort.Protocol
+	}
+	if overridePort.HostIP != "" {
+		mergedPort.HostIP = overridePort.HostIP
+	}
+	return mergedPort
+}
+
+// ContainerPortSlicesByName takes two slices of corev1.ContainerPorts, these values are merged by name.
+// if there are elements present in the overridePorts that are not present in defaultPorts, they are
+// appended to the end.
+func ContainerPortSlicesByName(defaultPorts, overridePorts []corev1.ContainerPort) []corev1.ContainerPort {
+	defaultPortMap := createContainerPortMap(defaultPorts)
+	overridePortsMap := createContainerPortMap(overridePorts)
+
+	mergedPorts := make([]corev1.ContainerPort, 0)
+
+	for portName, defaultPort := range defaultPortMap {
+		if overridePort, ok := overridePortsMap[portName]; ok {
+			mergedPorts = append(mergedPorts, ContainerPorts(defaultPort, overridePort))
+		} else {
+			mergedPorts = append(mergedPorts, defaultPort)
+		}
+	}
+
+	for portName, overridePort := range overridePortsMap {
+		if _, ok := defaultPortMap[portName]; !ok {
+			mergedPorts = append(mergedPorts, overridePort)
+		}
+	}
+
+	sort.SliceStable(mergedPorts, func(i, j int) bool {
+		return mergedPorts[i].Name < mergedPorts[j].Name
+	})
+
+	return mergedPorts
+}
+
+func createContainerPortMap(containerPorts []corev1.ContainerPort) map[string]corev1.ContainerPort {
+	containerPortMap := make(map[string]corev1.ContainerPort)
+	for _, m := range containerPorts {
+		containerPortMap[m.Name] = m
+	}
+	return containerPortMap
+}
+
+// VolumeMounts merges two slices of volume mounts by name.
+func VolumeMounts(original, override []corev1.VolumeMount) []corev1.VolumeMount {
+	mergedMountsMap := map[string]corev1.VolumeMount{}
+	originalMounts := createVolumeMountMap(original)
+	overrideMounts := createVolumeMountMap(override)
+
+	for k, v := range originalMounts {
+		mergedMountsMap[k] = v
+	}
+
+	for k, v := range overrideMounts {
+		if orig, ok := originalMounts[k]; ok {
+			mergedMountsMap[k] = VolumeMount(orig, v)
+		} else {
+			mergedMountsMap[k] = v
+		}
+	}
+
+	var mergedMounts []corev1.VolumeMount
+	for _, mount := range mergedMountsMap {
+		mergedMounts = append(mergedMounts, mount)
+	}
+
+	sort.SliceStable(mergedMounts, func(i, j int) bool {
+		return volumeMountToString(mergedMounts[i]) < volumeMountToString(mergedMounts[j])
+	})
+
+	return mergedMounts
+}
+
+// volumeMountToString returns a string consisting of all components of the given VolumeMount.
+func volumeMountToString(v corev1.VolumeMount) string {
+	return strings.Join([]string{v.Name, v.MountPath, v.SubPath}, "_")
+}
+
+func createVolumeMountMap(mounts []corev1.VolumeMount) map[string]corev1.VolumeMount {
+	m := make(map[string]corev1.VolumeMount)
+	for _, v := range mounts {
+		m[volumeMountToString(v)] = v
+	}
+	return m
+}
+
+// VolumeMount merges two corev1.VolumeMounts. Any fields in the override take precedence
+// over the values in the original. Thw new VolumeMount is returned.
+func VolumeMount(original, override corev1.VolumeMount) corev1.VolumeMount {
+	merged := original
+
+	if override.Name != "" {
+		merged.Name = override.Name
+	}
+
+	if override.ReadOnly {
+		merged.ReadOnly = override.ReadOnly
+	}
+
+	if override.MountPath != "" {
+		merged.MountPath = override.MountPath
+	}
+
+	if override.SubPath != "" {
+		merged.SubPath = override.SubPath
+	}
+
+	if override.MountPropagation != nil {
+		merged.MountPropagation = override.MountPropagation
+	}
+
+	if override.SubPathExpr != "" {
+		merged.SubPathExpr = override.SubPathExpr
+	}
+	return merged
+}
+
+func Tolerations(defaultTolerations, overrideTolerations []corev1.Toleration) []corev1.Toleration {
+	mergedTolerations := make([]corev1.Toleration, 0)
+	defaultMap := createTolerationsMap(defaultTolerations)
+	for _, v := range overrideTolerations {
+		defaultMap[v.Key] = v
+	}
+
+	for _, v := range defaultMap {
+		mergedTolerations = append(mergedTolerations, v)
+	}
+
+	if len(mergedTolerations) == 0 {
+		return nil
+	}
+
+	sort.SliceStable(mergedTolerations, func(i, j int) bool {
+		return mergedTolerations[i].Key < mergedTolerations[j].Key
+	})
+
+	return mergedTolerations
+}
+
+func createTolerationsMap(tolerations []corev1.Toleration) map[string]corev1.Toleration {
+	tolerationsMap := make(map[string]corev1.Toleration)
+	for _, t := range tolerations {
+		tolerationsMap[t.Key] = t
+	}
+	return tolerationsMap
+}
+
+func Volumes(defaultVolumes []corev1.Volume, overrideVolumes []corev1.Volume) []corev1.Volume {
+	defaultVolumesMap := createVolumesMap(defaultVolumes)
+	overrideVolumesMap := createVolumesMap(overrideVolumes)
+	mergedVolumes := []corev1.Volume{}
+
+	for _, defaultVolume := range defaultVolumes {
+		mergedVolume := defaultVolume
+		if overrideVolume, ok := overrideVolumesMap[defaultVolume.Name]; ok {
+			mergedVolume = Volume(defaultVolume, overrideVolume)
+		}
+		mergedVolumes = append(mergedVolumes, mergedVolume)
+	}
+
+	for _, overrideVolume := range overrideVolumes {
+		if _, ok := defaultVolumesMap[overrideVolume.Name]; ok {
+			// Already Merged
+			continue
+		}
+		mergedVolumes = append(mergedVolumes, overrideVolume)
+	}
+
+	sort.SliceStable(mergedVolumes, func(i, j int) bool {
+		return mergedVolumes[i].Name < mergedVolumes[j].Name
+	})
+	return mergedVolumes
+}
+
+func Volume(defaultVolume corev1.Volume, overrideVolume corev1.Volume) corev1.Volume {
+	// Volume contains only Name and VolumeSource
+
+	// Merge VolumeSource
+	overrideSource := overrideVolume.VolumeSource
+	defaultSource := defaultVolume.VolumeSource
+	mergedVolume := defaultVolume
+
+	// Only one field must be non-nil.
+	// We merge if it is one of the ones we fill from the operator side:
+	// - EmptyDir
+	if overrideSource.EmptyDir != nil && defaultSource.EmptyDir != nil {
+		if overrideSource.EmptyDir.Medium != "" {
+			mergedVolume.EmptyDir.Medium = overrideSource.EmptyDir.Medium
+		}
+		if overrideSource.EmptyDir.SizeLimit != nil {
+			mergedVolume.EmptyDir.SizeLimit = overrideSource.EmptyDir.SizeLimit
+		}
+		return mergedVolume
+	}
+	// - Secret
+	if overrideSource.Secret != nil && defaultSource.Secret != nil {
+		if overrideSource.Secret.SecretName != "" {
+			mergedVolume.Secret.SecretName = overrideSource.Secret.SecretName
+		}
+		mergedVolume.Secret.Items = mergeKeyToPathItems(defaultSource.Secret.Items, overrideSource.Secret.Items)
+		if overrideSource.Secret.DefaultMode != nil {
+			mergedVolume.Secret.DefaultMode = overrideSource.Secret.DefaultMode
+		}
+		return mergedVolume
+	}
+	// - ConfigMap
+	if overrideSource.ConfigMap != nil && defaultSource.ConfigMap != nil {
+		if overrideSource.ConfigMap.LocalObjectReference.Name != "" {
+			mergedVolume.ConfigMap.LocalObjectReference.Name = overrideSource.ConfigMap.LocalObjectReference.Name
+		}
+		mergedVolume.ConfigMap.Items = mergeKeyToPathItems(defaultSource.ConfigMap.Items, overrideSource.ConfigMap.Items)
+		if overrideSource.ConfigMap.DefaultMode != nil {
+			mergedVolume.ConfigMap.DefaultMode = overrideSource.ConfigMap.DefaultMode
+		}
+		if overrideSource.ConfigMap.Optional != nil {
+			mergedVolume.ConfigMap.Optional = overrideSource.ConfigMap.Optional
+		}
+		return mergedVolume
+	}
+
+	// Otherwise we assume that the user provides every field
+	// and we just assign it and nil every other field
+	// We also do that in the case the user provides one of the three listed above
+	// but our volume has a different non-nil entry.
+
+	// this is effectively the same as just returning the overrideSource
+	mergedVolume.VolumeSource = overrideSource
+	return mergedVolume
+}
+
+func createVolumesMap(volumes []corev1.Volume) map[string]corev1.Volume {
+	volumesMap := make(map[string]corev1.Volume)
+	for _, v := range volumes {
+		volumesMap[v.Name] = v
+	}
+	return volumesMap
+}
+
+func mergeKeyToPathItems(defaultItems []corev1.KeyToPath, overrideItems []corev1.KeyToPath) []corev1.KeyToPath {
+	// Merge Items array by KeyToPath.Key entry
+	defaultItemsMap := createKeyToPathMap(defaultItems)
+	overrideItemsMap := createKeyToPathMap(overrideItems)
+	var mergedItems []corev1.KeyToPath
+	for _, defaultItem := range defaultItemsMap {
+		mergedKey := defaultItem
+		if overrideItem, ok := overrideItemsMap[defaultItem.Key]; ok {
+			// Need to merge
+			mergedKey = mergeKeyToPath(defaultItem, overrideItem)
+		}
+		mergedItems = append(mergedItems, mergedKey)
+	}
+	for _, overrideItem := range overrideItemsMap {
+		if _, ok := defaultItemsMap[overrideItem.Key]; ok {
+			// Already merged
+			continue
+		}
+		mergedItems = append(mergedItems, overrideItem)
+
+	}
+	return mergedItems
+}
+
+func mergeKeyToPath(defaultKey corev1.KeyToPath, overrideKey corev1.KeyToPath) corev1.KeyToPath {
+	if defaultKey.Key != overrideKey.Key {
+		// This should not happen as we always merge by Key.
+		// If it does, we return the default as something's wrong
+		return defaultKey
+	}
+	if overrideKey.Path != "" {
+		defaultKey.Path = overrideKey.Path
+	}
+	if overrideKey.Mode != nil {
+		defaultKey.Mode = overrideKey.Mode
+	}
+	return defaultKey
+}
+
+func createKeyToPathMap(items []corev1.KeyToPath) map[string]corev1.KeyToPath {
+	itemsMap := make(map[string]corev1.KeyToPath)
+	for _, v := range items {
+		itemsMap[v.Key] = v
+	}
+	return itemsMap
+}
+
+// Affinity merges two corev1.Affinity types.
+func Affinity(defaultAffinity, overrideAffinity *corev1.Affinity) *corev1.Affinity {
+	if defaultAffinity == nil {
+		return overrideAffinity
+	}
+	if overrideAffinity == nil {
+		return defaultAffinity
+	}
+	mergedAffinity := defaultAffinity.DeepCopy()
+	if overrideAffinity.NodeAffinity != nil {
+		mergedAffinity.NodeAffinity = overrideAffinity.NodeAffinity
+	}
+	if overrideAffinity.PodAffinity != nil {
+		mergedAffinity.PodAffinity = overrideAffinity.PodAffinity
+	}
+	if overrideAffinity.PodAntiAffinity != nil {
+		mergedAffinity.PodAntiAffinity = overrideAffinity.PodAntiAffinity
+	}
+	return mergedAffinity
+}

--- a/operator/pkg/util/merge/merge_deployment.go
+++ b/operator/pkg/util/merge/merge_deployment.go
@@ -1,0 +1,20 @@
+package merge
+
+import appsv1 "k8s.io/api/apps/v1"
+
+// StatefulSetSpecs merges two StatefulSetSpecs together.
+func DeploymentSpecs(defaultSpec, overrideSpec appsv1.DeploymentSpec) appsv1.DeploymentSpec {
+	mergedSpec := defaultSpec
+	if overrideSpec.Replicas != nil {
+		mergedSpec.Replicas = overrideSpec.Replicas
+	}
+
+	mergedSpec.Selector = LabelSelectors(defaultSpec.Selector, overrideSpec.Selector)
+
+	if overrideSpec.RevisionHistoryLimit != nil {
+		mergedSpec.RevisionHistoryLimit = overrideSpec.RevisionHistoryLimit
+	}
+
+	mergedSpec.Template = PodTemplateSpecs(defaultSpec.Template, overrideSpec.Template)
+	return mergedSpec
+}

--- a/operator/pkg/util/merge/merge_ephemeral_container.go
+++ b/operator/pkg/util/merge/merge_ephemeral_container.go
@@ -1,0 +1,107 @@
+package merge
+
+import (
+	corev1 "k8s.io/api/core/v1"
+)
+
+// EphemeralContainers merges two slices of EphemeralContainers merging each item by container name.
+func EphemeralContainers(defaultContainers, overrideContainers []corev1.EphemeralContainer) []corev1.EphemeralContainer {
+	mergedContainerMap := map[string]corev1.EphemeralContainer{}
+
+	originalMap := createEphemeralContainerMap(defaultContainers)
+	overrideMap := createEphemeralContainerMap(overrideContainers)
+
+	for k, v := range originalMap {
+		mergedContainerMap[k] = v
+	}
+
+	for k, v := range overrideMap {
+		if orig, ok := originalMap[k]; ok {
+			mergedContainerMap[k] = EphemeralContainer(orig, v)
+		} else {
+			mergedContainerMap[k] = v
+		}
+	}
+
+	var mergedContainers []corev1.EphemeralContainer
+	for _, v := range mergedContainerMap {
+		mergedContainers = append(mergedContainers, v)
+	}
+
+	//sort.SliceStable(mergedContainers, func(i, j int) bool {
+	//	return mergedContainers[i].Name < mergedContainers[j].Name
+	//})
+	return mergedContainers
+
+}
+
+// EphemeralContainer merges two EphemeralContainers together.
+func EphemeralContainer(defaultContainer, overrideContainer corev1.EphemeralContainer) corev1.EphemeralContainer {
+	merged := defaultContainer
+
+	if overrideContainer.Name != "" {
+		merged.Name = overrideContainer.Name
+	}
+
+	if overrideContainer.Image != "" {
+		merged.Image = overrideContainer.Image
+	}
+
+	merged.Command = StringSlices(defaultContainer.Command, overrideContainer.Command)
+	merged.Args = StringSlices(defaultContainer.Args, overrideContainer.Args)
+
+	if overrideContainer.WorkingDir != "" {
+		merged.WorkingDir = overrideContainer.WorkingDir
+	}
+
+	merged.Ports = ContainerPortSlicesByName(defaultContainer.Ports, overrideContainer.Ports)
+	merged.Env = Envs(defaultContainer.Env, overrideContainer.Env)
+	merged.Resources = ResourceRequirements(defaultContainer.Resources, overrideContainer.Resources)
+	merged.VolumeMounts = VolumeMounts(defaultContainer.VolumeMounts, overrideContainer.VolumeMounts)
+	merged.VolumeDevices = VolumeDevices(defaultContainer.VolumeDevices, overrideContainer.VolumeDevices)
+	merged.LivenessProbe = Probe(defaultContainer.LivenessProbe, overrideContainer.LivenessProbe)
+	merged.ReadinessProbe = Probe(defaultContainer.ReadinessProbe, overrideContainer.ReadinessProbe)
+	merged.StartupProbe = Probe(defaultContainer.StartupProbe, overrideContainer.StartupProbe)
+	merged.Lifecycle = LifeCycle(defaultContainer.Lifecycle, overrideContainer.Lifecycle)
+
+	if overrideContainer.TerminationMessagePath != "" {
+		merged.TerminationMessagePath = overrideContainer.TerminationMessagePath
+	}
+
+	if overrideContainer.TerminationMessagePolicy != "" {
+		merged.TerminationMessagePolicy = overrideContainer.TerminationMessagePolicy
+	}
+
+	if overrideContainer.ImagePullPolicy != "" {
+		merged.ImagePullPolicy = overrideContainer.ImagePullPolicy
+	}
+
+	merged.SecurityContext = SecurityContext(defaultContainer.SecurityContext, overrideContainer.SecurityContext)
+
+	if overrideContainer.Stdin {
+		merged.Stdin = overrideContainer.Stdin
+	}
+
+	if overrideContainer.StdinOnce {
+		merged.StdinOnce = overrideContainer.StdinOnce
+	}
+
+	if overrideContainer.TTY {
+		merged.TTY = overrideContainer.TTY
+	}
+
+	// EphemeralContainer only fields
+	if overrideContainer.TargetContainerName != "" {
+		merged.TargetContainerName = overrideContainer.TargetContainerName
+	}
+
+	return merged
+}
+
+func createEphemeralContainerMap(containers []corev1.EphemeralContainer) map[string]corev1.EphemeralContainer {
+	m := make(map[string]corev1.EphemeralContainer)
+	for _, v := range containers {
+		m[v.Name] = v
+	}
+	return m
+}

--- a/operator/pkg/util/merge/merge_podtemplate_spec.go
+++ b/operator/pkg/util/merge/merge_podtemplate_spec.go
@@ -1,0 +1,250 @@
+package merge
+
+import (
+	"sort"
+
+	"nacos.io/nacos-operator/pkg/util/contains"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func PodSpec(original, override corev1.PodSpec) corev1.PodSpec {
+	merged := original
+
+	merged.Volumes = Volumes(original.Volumes, override.Volumes)
+	merged.Containers = Containers(original.Containers, override.Containers)
+	merged.InitContainers = Containers(original.InitContainers, override.InitContainers)
+
+	if override.EphemeralContainers != nil {
+		merged.EphemeralContainers = EphemeralContainers(original.EphemeralContainers, override.EphemeralContainers)
+	}
+
+	if override.RestartPolicy != "" {
+		merged.RestartPolicy = override.RestartPolicy
+	}
+
+	if override.TerminationGracePeriodSeconds != nil {
+		merged.TerminationGracePeriodSeconds = override.TerminationGracePeriodSeconds
+	}
+	if override.ActiveDeadlineSeconds != nil {
+		merged.ActiveDeadlineSeconds = override.ActiveDeadlineSeconds
+	}
+
+	if override.DNSPolicy != "" {
+		merged.DNSPolicy = override.DNSPolicy
+	}
+
+	if override.NodeSelector != nil {
+		merged.NodeSelector = StringToStringMap(original.NodeSelector, override.NodeSelector)
+	}
+
+	if override.ServiceAccountName != "" {
+		merged.ServiceAccountName = override.ServiceAccountName
+	}
+
+	if override.DeprecatedServiceAccount != "" {
+		merged.DeprecatedServiceAccount = override.DeprecatedServiceAccount
+	}
+
+	if override.AutomountServiceAccountToken != nil {
+		merged.AutomountServiceAccountToken = override.AutomountServiceAccountToken
+	}
+
+	if override.NodeName != "" {
+		merged.NodeName = override.NodeName
+	}
+
+	if override.HostNetwork {
+		merged.HostNetwork = override.HostNetwork
+	}
+
+	if override.HostPID {
+		merged.HostPID = override.HostPID
+	}
+
+	if override.ShareProcessNamespace != nil {
+		merged.ShareProcessNamespace = override.ShareProcessNamespace
+	}
+
+	if override.SecurityContext != nil {
+		merged.SecurityContext = override.SecurityContext
+	}
+
+	if override.ImagePullSecrets != nil {
+		merged.ImagePullSecrets = override.ImagePullSecrets
+	}
+
+	if override.Hostname != "" {
+		merged.Hostname = override.Hostname
+	}
+
+	if override.Subdomain != "" {
+		merged.Subdomain = override.Subdomain
+	}
+
+	if override.Affinity != nil {
+		merged.Affinity = Affinity(original.Affinity, override.Affinity)
+	}
+
+	if override.SchedulerName != "" {
+		merged.SchedulerName = override.SchedulerName
+	}
+
+	merged.Tolerations = Tolerations(original.Tolerations, override.Tolerations)
+
+	merged.HostAliases = HostAliases(original.HostAliases, override.HostAliases)
+
+	if override.PriorityClassName != "" {
+		merged.PriorityClassName = override.PriorityClassName
+	}
+
+	if override.Priority != nil {
+		merged.Priority = override.Priority
+	}
+
+	if override.DNSConfig != nil {
+		merged.DNSConfig = PodDNSConfig(original.DNSConfig, override.DNSConfig)
+	}
+
+	if override.ReadinessGates != nil {
+		merged.ReadinessGates = override.ReadinessGates
+	}
+
+	if override.RuntimeClassName != nil {
+		merged.RuntimeClassName = override.RuntimeClassName
+	}
+
+	if override.EnableServiceLinks != nil {
+		merged.EnableServiceLinks = override.EnableServiceLinks
+	}
+
+	if override.PreemptionPolicy != nil {
+		merged.PreemptionPolicy = override.PreemptionPolicy
+	}
+
+	if override.Overhead != nil {
+		merged.Overhead = override.Overhead
+	}
+
+	if override.TopologySpreadConstraints != nil {
+		merged.TopologySpreadConstraints = TopologySpreadConstraints(original.TopologySpreadConstraints, override.TopologySpreadConstraints)
+	}
+
+	return merged
+}
+func PodTemplateSpecs(original, override corev1.PodTemplateSpec) corev1.PodTemplateSpec {
+	merged := original
+
+	merged.Annotations = StringToStringMap(original.Annotations, override.Annotations)
+	merged.Labels = StringToStringMap(original.Labels, override.Labels)
+	merged.Spec = PodSpec(merged.Spec,override.Spec)
+	return merged
+}
+
+func TopologySpreadConstraints(original, override []corev1.TopologySpreadConstraint) []corev1.TopologySpreadConstraint {
+	originalMap := createTopologySpreadConstraintMap(original)
+	overrideMap := createTopologySpreadConstraintMap(override)
+
+	mergedMap := map[string]corev1.TopologySpreadConstraint{}
+
+	for k, v := range originalMap {
+		mergedMap[k] = v
+	}
+	for k, v := range overrideMap {
+		if originalValue, ok := mergedMap[k]; ok {
+			mergedMap[k] = TopologySpreadConstraint(originalValue, v)
+		} else {
+			mergedMap[k] = v
+		}
+	}
+	var mergedElements []corev1.TopologySpreadConstraint
+	for _, v := range mergedMap {
+		mergedElements = append(mergedElements, v)
+	}
+	return mergedElements
+}
+
+func TopologySpreadConstraint(original, override corev1.TopologySpreadConstraint) corev1.TopologySpreadConstraint {
+	merged := original
+	if override.LabelSelector != nil {
+		merged.LabelSelector = override.LabelSelector
+	}
+	if override.MaxSkew != 0 {
+		merged.MaxSkew = override.MaxSkew
+	}
+	if override.WhenUnsatisfiable != "" {
+		merged.WhenUnsatisfiable = override.WhenUnsatisfiable
+	}
+	return merged
+}
+
+func createTopologySpreadConstraintMap(constraints []corev1.TopologySpreadConstraint) map[string]corev1.TopologySpreadConstraint {
+	m := make(map[string]corev1.TopologySpreadConstraint)
+	for _, v := range constraints {
+		m[v.TopologyKey] = v
+	}
+	return m
+}
+
+// HostAliases merges two slices of HostAliases together. Any shared hostnames with a given
+// ip are merged together into fewer entries.
+func HostAliases(originalAliases, overrideAliases []corev1.HostAlias) []corev1.HostAlias {
+	m := make(map[string]corev1.HostAlias)
+	for _, original := range originalAliases {
+		m[original.IP] = original
+	}
+
+	for _, override := range overrideAliases {
+		if _, ok := m[override.IP]; ok {
+			var mergedHostNames []string
+			mergedHostNames = append(mergedHostNames, m[override.IP].Hostnames...)
+			for _, hn := range override.Hostnames {
+				if !contains.String(mergedHostNames, hn) {
+					mergedHostNames = append(mergedHostNames, hn)
+				}
+			}
+			m[override.IP] = corev1.HostAlias{
+				IP:        override.IP,
+				Hostnames: mergedHostNames,
+			}
+		} else {
+			m[override.IP] = override
+		}
+	}
+
+	var mergedHostAliases []corev1.HostAlias
+	for _, v := range m {
+		mergedHostAliases = append(mergedHostAliases, v)
+	}
+
+	sort.SliceStable(mergedHostAliases, func(i, j int) bool {
+		return mergedHostAliases[i].IP < mergedHostAliases[j].IP
+	})
+
+	return mergedHostAliases
+}
+
+func PodDNSConfig(originalDNSConfig, overrideDNSConfig *corev1.PodDNSConfig) *corev1.PodDNSConfig {
+	if overrideDNSConfig == nil {
+		return originalDNSConfig
+	}
+
+	if originalDNSConfig == nil {
+		return overrideDNSConfig
+	}
+
+	merged := originalDNSConfig.DeepCopy()
+
+	if overrideDNSConfig.Options != nil {
+		merged.Options = overrideDNSConfig.Options
+	}
+
+	if overrideDNSConfig.Nameservers != nil {
+		merged.Nameservers = StringSlices(merged.Nameservers, overrideDNSConfig.Nameservers)
+	}
+
+	if overrideDNSConfig.Searches != nil {
+		merged.Searches = StringSlices(merged.Searches, overrideDNSConfig.Searches)
+	}
+
+	return merged
+}

--- a/operator/pkg/util/merge/merge_statefulset.go
+++ b/operator/pkg/util/merge/merge_statefulset.go
@@ -1,0 +1,204 @@
+package merge
+
+import (
+	"sort"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"nacos.io/nacos-operator/pkg/util/contains"
+)
+
+// StatefulSets merges two StatefulSets together.
+func StatefulSets(defaultStatefulSet, overrideStatefulSet appsv1.StatefulSet) appsv1.StatefulSet {
+	mergedSts := defaultStatefulSet
+	mergedSts.Labels = StringToStringMap(defaultStatefulSet.Labels, overrideStatefulSet.Labels)
+	if overrideStatefulSet.Namespace != "" {
+		mergedSts.Namespace = overrideStatefulSet.Namespace
+	}
+	if overrideStatefulSet.Name != "" {
+		mergedSts.Name = overrideStatefulSet.Name
+	}
+	mergedSts.Spec = StatefulSetSpecs(defaultStatefulSet.Spec, overrideStatefulSet.Spec)
+	return mergedSts
+}
+
+// StatefulSetSpecs merges two StatefulSetSpecs together.
+func StatefulSetSpecs(defaultSpec, overrideSpec appsv1.StatefulSetSpec) appsv1.StatefulSetSpec {
+	mergedSpec := defaultSpec
+	if overrideSpec.Replicas != nil {
+		mergedSpec.Replicas = overrideSpec.Replicas
+	}
+
+	mergedSpec.Selector = LabelSelectors(defaultSpec.Selector, overrideSpec.Selector)
+
+	if overrideSpec.PodManagementPolicy != "" {
+		mergedSpec.PodManagementPolicy = overrideSpec.PodManagementPolicy
+	}
+
+	if overrideSpec.RevisionHistoryLimit != nil {
+		mergedSpec.RevisionHistoryLimit = overrideSpec.RevisionHistoryLimit
+	}
+
+	if overrideSpec.UpdateStrategy.Type != "" {
+		mergedSpec.UpdateStrategy.Type = overrideSpec.UpdateStrategy.Type
+	}
+
+	if overrideSpec.UpdateStrategy.RollingUpdate != nil {
+		mergedSpec.UpdateStrategy.RollingUpdate = overrideSpec.UpdateStrategy.RollingUpdate
+	}
+
+	if overrideSpec.ServiceName != "" {
+		mergedSpec.ServiceName = overrideSpec.ServiceName
+	}
+
+	mergedSpec.Template = PodTemplateSpecs(defaultSpec.Template, overrideSpec.Template)
+	mergedSpec.VolumeClaimTemplates = VolumeClaimTemplates(defaultSpec.VolumeClaimTemplates, overrideSpec.VolumeClaimTemplates)
+	return mergedSpec
+}
+
+func LabelSelectors(originalLabelSelector, overrideLabelSelector *metav1.LabelSelector) *metav1.LabelSelector {
+	// we have only specified a label selector in the override
+	if overrideLabelSelector == nil {
+		return originalLabelSelector
+	}
+	// we have only specified a label selector in the original
+	if originalLabelSelector == nil {
+		return originalLabelSelector
+	}
+
+	// we have specified both, so we must merge them
+	mergedLabelSelector := &metav1.LabelSelector{}
+	mergedLabelSelector.MatchLabels = StringToStringMap(originalLabelSelector.MatchLabels, overrideLabelSelector.MatchLabels)
+	mergedLabelSelector.MatchExpressions = LabelSelectorRequirements(originalLabelSelector.MatchExpressions, overrideLabelSelector.MatchExpressions)
+	return mergedLabelSelector
+}
+
+// LabelSelectorRequirements accepts two slices of LabelSelectorRequirement. Any LabelSelectorRequirement in the override
+// slice that has the same key as one from the original is merged. Otherwise they are appended to the list.
+func LabelSelectorRequirements(original, override []metav1.LabelSelectorRequirement) []metav1.LabelSelectorRequirement {
+	mergedLsrs := make([]metav1.LabelSelectorRequirement, 0)
+	for _, originalLsr := range original {
+		mergedLsr := originalLsr
+		overrideLsr := LabelSelectorRequirementByKey(override, originalLsr.Key)
+		if overrideLsr != nil {
+			if overrideLsr.Operator != "" {
+				mergedLsr.Operator = overrideLsr.Operator
+			}
+			if overrideLsr.Values != nil {
+				mergedLsr.Values = StringSlices(originalLsr.Values, overrideLsr.Values)
+			}
+		}
+		sort.SliceStable(mergedLsr.Values, func(i, j int) bool {
+			return mergedLsr.Values[i] < mergedLsr.Values[j]
+		})
+
+		mergedLsrs = append(mergedLsrs, mergedLsr)
+	}
+
+	// we need to add any override lsrs that do not exist in the original
+	for _, overrideLsr := range override {
+		existing := LabelSelectorRequirementByKey(original, overrideLsr.Key)
+		if existing == nil {
+			sort.SliceStable(overrideLsr.Values, func(i, j int) bool {
+				return overrideLsr.Values[i] < overrideLsr.Values[j]
+			})
+			mergedLsrs = append(mergedLsrs, overrideLsr)
+		}
+	}
+
+	// sort them by key
+	sort.SliceStable(mergedLsrs, func(i, j int) bool {
+		return mergedLsrs[i].Key < mergedLsrs[j].Key
+	})
+
+	return mergedLsrs
+}
+
+// LabelSelectorRequirementByKey returns the LabelSelectorRequirement with the given key if present in the slice.
+// returns nil if not present.
+func LabelSelectorRequirementByKey(labelSelectorRequirements []metav1.LabelSelectorRequirement, key string) *metav1.LabelSelectorRequirement {
+	for _, lsr := range labelSelectorRequirements {
+		if lsr.Key == key {
+			return &lsr
+		}
+	}
+	return nil
+}
+
+func VolumeClaimTemplates(defaultTemplates []corev1.PersistentVolumeClaim, overrideTemplates []corev1.PersistentVolumeClaim) []corev1.PersistentVolumeClaim {
+	defaultMountsMap := createVolumeClaimMap(defaultTemplates)
+	overrideMountsMap := createVolumeClaimMap(overrideTemplates)
+
+	mergedMap := map[string]corev1.PersistentVolumeClaim{}
+
+	for _, vct := range defaultMountsMap {
+		mergedMap[vct.Name] = vct
+	}
+
+	for _, overrideClaim := range overrideMountsMap {
+		if defaultClaim, ok := defaultMountsMap[overrideClaim.Name]; ok {
+			mergedMap[overrideClaim.Name] = PersistentVolumeClaim(defaultClaim, overrideClaim)
+		} else {
+			mergedMap[overrideClaim.Name] = overrideClaim
+		}
+	}
+
+	var mergedVolumes []corev1.PersistentVolumeClaim
+	for _, v := range mergedMap {
+		mergedVolumes = append(mergedVolumes, v)
+	}
+
+	sort.SliceStable(mergedVolumes, func(i, j int) bool {
+		return mergedVolumes[i].Name < mergedVolumes[j].Name
+	})
+
+	return mergedVolumes
+}
+
+func createVolumeClaimMap(volumeMounts []corev1.PersistentVolumeClaim) map[string]corev1.PersistentVolumeClaim {
+	mountMap := make(map[string]corev1.PersistentVolumeClaim)
+	for _, m := range volumeMounts {
+		mountMap[m.Name] = m
+	}
+	return mountMap
+}
+
+func PersistentVolumeClaim(defaultPvc corev1.PersistentVolumeClaim, overridePvc corev1.PersistentVolumeClaim) corev1.PersistentVolumeClaim {
+	if overridePvc.Namespace != "" {
+		defaultPvc.Namespace = overridePvc.Namespace
+	}
+
+	if overridePvc.Spec.VolumeMode != nil {
+		defaultPvc.Spec.VolumeMode = overridePvc.Spec.VolumeMode
+	}
+
+	if overridePvc.Spec.StorageClassName != nil {
+		defaultPvc.Spec.StorageClassName = overridePvc.Spec.StorageClassName
+	}
+
+	for _, accessMode := range overridePvc.Spec.AccessModes {
+		if !contains.AccessMode(defaultPvc.Spec.AccessModes, accessMode) {
+			defaultPvc.Spec.AccessModes = append(defaultPvc.Spec.AccessModes, accessMode)
+		}
+	}
+
+	if overridePvc.Spec.Selector != nil {
+		defaultPvc.Spec.Selector = overridePvc.Spec.Selector
+	}
+
+	if overridePvc.Spec.Resources.Limits != nil {
+		defaultPvc.Spec.Resources.Limits = overridePvc.Spec.Resources.Limits
+	}
+
+	if overridePvc.Spec.Resources.Requests != nil {
+		defaultPvc.Spec.Resources.Requests = overridePvc.Spec.Resources.Requests
+	}
+
+	if overridePvc.Spec.DataSource != nil {
+		defaultPvc.Spec.DataSource = overridePvc.Spec.DataSource
+	}
+
+	return defaultPvc
+}


### PR DESCRIPTION
Support nacos-operator k8s general-configuration,  
For example, tolerations and nodeSelector
```
...
spec:
  ...
  k8sWrapper:
    PodSpec:
      nodeSelector:
        disktype: ssd
      tolerations:
        - key: "example-key"
          operator: "Exists"
          effect: "NoSchedule"

```