### PR TITLE
修复使用nacos_mysql.yaml nacos还是以embedded模式启动

### DIFF
--- a/operator/pkg/service/operator/Kind.go
+++ b/operator/pkg/service/operator/Kind.go
@@ -452,6 +452,12 @@ func (e *KindClient) buildStatefulset(nacos *nacosgroupv1alpha1.Nacos) *appv1.St
 			Value: "embedded",
 		})
 	} else if nacos.Spec.Database.TypeDatabase == "mysql" {
+		
+		env = append(env, v1.EnvVar{
+			Name:  "SPRING_DATASOURCE_PLATFORM",
+			Value: nacos.Spec.Database.TypeDatabase,
+		})
+		
 		env = append(env, v1.EnvVar{
 			Name:  "MYSQL_SERVICE_HOST",
 			Value: nacos.Spec.Database.MysqlHost,


### PR DESCRIPTION
apiVersion: nacos.io/v1alpha1
kind: Nacos
metadata:
  name: nacos
spec:
  # standalone/cluster
  type: standalone
  image: nacos/nacos-server:1.4.1
  replicas: 1
  resources:
    requests:
      cpu: 100m
      memory: 512Mi
    limits:
      cpu: 2
      memory: 2Gi
  mysqlInitImage: "registry.cn-hangzhou.aliyuncs.com/choerodon-tools/mysql-client:10.2.15-r0"
  database:
    type: mysql
    mysqlHost: mysql
    mysqlDb: nacos
    mysqlUser: root
    mysqlPort: "3306"
    mysqlPassword: "123456"

使用这个 nacos_mysql.yaml 创建完cr之后 nacos以embedded模式启动


