### PR TITLE
solve nacos CRD deploy error on  K8s v1.22+ cluster

### DIFF
--- a/operator/Makefile
+++ b/operator/Makefile
@@ -92,7 +92,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.3.0 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@v0.6.2 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOBIN)/controller-gen
@@ -107,7 +107,7 @@ ifeq (, $(shell which kustomize))
 	KUSTOMIZE_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$KUSTOMIZE_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/kustomize/kustomize/v3@v3.5.4 ;\
+	go get sigs.k8s.io/kustomize/kustomize/v4@v4.1.2 ;\
 	rm -rf $$KUSTOMIZE_GEN_TMP_DIR ;\
 	}
 KUSTOMIZE=$(GOBIN)/kustomize

--- a/operator/pkg/service/operator/Kind.go
+++ b/operator/pkg/service/operator/Kind.go
@@ -527,6 +527,17 @@ func (e *KindClient) buildStatefulset(nacos *nacosgroupv1alpha1.Nacos) *appv1.St
 						{
 							Name:  nacos.Name,
 							Image: nacos.Spec.Image,
+							Lifecycle: &v1.Lifecycle{
+								PreStop: &v1.Handler{
+									Exec: &v1.ExecAction{
+										Command: []string{
+											"/bin/sh",
+											"-c",
+											"rm -rf /home/nacos/data/protocol/raft",
+										},
+									},
+								},
+							},
 							Ports: []v1.ContainerPort{
 								{
 									Name:          "client",


### PR DESCRIPTION
solve nacos crd deploy problems  on v1.22+ K8s clusters ,see https://github.com/nacos-group/nacos-k8s/issues/355