### PR TITLE
add leases in rules

### DIFF
--- a/operator/chart/nacos-operator/templates/serviceaccount.yaml
+++ b/operator/chart/nacos-operator/templates/serviceaccount.yaml
@@ -66,5 +66,16 @@ rules:
       - patch
       - list
       - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
+      - patch
+      - list
+      - watch
 
 {{- end }}


### PR DESCRIPTION
to resolve the following error:

error log in operator pod while applying config/samples/nacos.yaml
> E1130 11:30:39.114705       1 leaderelection.go:325] error retrieving resource lock nacos/219866ca.nacos.io: 
> leases.coordination.k8s.io "219866ca.nacos.io" is forbidden: User "system:serviceaccount:nacos:nacos-operator" cannot > get resource "leases" in API group "coordination.k8s.io" in the namespace "nacos"