### PR TITLE
更新适配k8s新版本的配置; 添加必须的环境变量配置

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -155,6 +155,7 @@ mysql-gf2vd                        1/1     Running   0          111m
 
 ```yaml
 data:
+  mysql.host: "数据库地址"
   mysql.db.name: "数据库名称"
   mysql.port: "端口"
   mysql.user: "用户名"

--- a/README-CN.md
+++ b/README-CN.md
@@ -282,6 +282,7 @@ for i in 0 1 2; do echo nacos-$i; kubectl exec nacos-$i curl GET "http://localho
 | mysql.port     | N       | 端口                        |
 | mysql.user     | Y       | 用户名                     |
 | mysql.password | Y       | 密码                     |
+| SPRING_DATASOURCE_PLATFORM | Y       | 数据库类型,默认embedded嵌入式数据库,参数只支持mysql或embedded                     |
 | NACOS_REPLICAS        | N      | 确定执行Nacos启动节点数量,如果不适用动态扩容插件,就必须配置这个属性，否则使用扩容插件后不会生效 |
 | NACOS_SERVER_PORT     | N       | Nacos 端口  为peer_finder插件提供端口          |
 | NACOS_APPLICATION_PORT     | N       | Nacos 端口             |

--- a/README.md
+++ b/README.md
@@ -285,6 +285,7 @@ You can find that the new node has joined the cluster
 | mysql.port     | N       | database port                          |
 | mysql.user     | Y       | database username                        |
 | mysql.password | Y       | database password                       |
+| SPRING_DATASOURCE_PLATFORM | Y       | Database type,The default is embedded database,parameters only support mysql or embedded                       |
 | NACOS_REPLICAS        | Y       | The number of clusters must be consistent with the value of the replicas attribute |
 | NACOS_SERVER_PORT     | N       | Nacos port,default:8848 for Peer-finder plugin               |
 | NACOS_APPLICATION_PORT     | N       | Nacos port， default:8848           |

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ mysql-gf2vd                        1/1     Running   0          111m
 
 ```yaml
 data:
+  mysql.host: "db host"
   mysql.db.name: "db name"
   mysql.port: " db port"
   mysql.user: " db username"

--- a/deploy/nacos/nacos-no-pvc-ingress.yaml
+++ b/deploy/nacos/nacos-no-pvc-ingress.yaml
@@ -31,11 +31,11 @@ kind: ConfigMap
 metadata:
   name: nacos-cm
 data:
-  mysql.host: "10.127.1.12"
+  mysql.host: "mysql"
   mysql.db.name: "nacos_devtest"
   mysql.port: "3306"
   mysql.user: "nacos"
-  mysql.password: "passwd"
+  mysql.password: "nacos"
 ---
 apiVersion: apps/v1
 kind: StatefulSet
@@ -62,7 +62,7 @@ spec:
                       - nacos
               topologyKey: "kubernetes.io/hostname"
       containers:
-        - name: k8snacos
+        - name: nacos
           imagePullPolicy: Always
           image: nacos/nacos-server:latest
           resources:
@@ -106,6 +106,8 @@ spec:
                 configMapKeyRef:
                   name: nacos-cm
                   key: mysql.password
+            - name: SPRING_DATASOURCE_PLATFORM
+              value: "mysql"
             - name: MODE
               value: "cluster"
             - name: NACOS_SERVER_PORT
@@ -123,12 +125,10 @@ spec:
 
 ---
 # ------------------- App Ingress ------------------- #
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: nacos-headless
-  namespace: default
-
 spec:
   rules:
   - host: nacos-web.nacos-demo.com
@@ -136,5 +136,7 @@ spec:
       paths:
       - path: /
         backend:
-          serviceName: nacos-headless
-          servicePort: server
+          service: 
+            name: nacos-headless
+            port:
+              name: server

--- a/deploy/nacos/nacos-pvc-ceph.yaml
+++ b/deploy/nacos/nacos-pvc-ceph.yaml
@@ -5,9 +5,8 @@ metadata:
   name: nacos-headless
   labels:
     app: nacos
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
+  publishNotReadyAddresses: true 
   ports:
     - port: 8848
       name: server
@@ -31,6 +30,7 @@ kind: ConfigMap
 metadata:
   name: nacos-cm
 data:
+  mysql.host: "mysql"
   mysql.db.name: "nacos_devtest"
   mysql.port: "3306"
   mysql.user: "nacos"
@@ -41,6 +41,7 @@ kind: StatefulSet
 metadata:
   name: nacos
 spec:
+  podManagementPolicy: Parallel
   serviceName: nacos-headless
   replicas: 3
   template:
@@ -98,6 +99,11 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: MYSQL_SERVICE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: nacos-cm
+                  key: mysql.host
             - name: MYSQL_SERVICE_DB_NAME
               valueFrom:
                 configMapKeyRef:
@@ -118,11 +124,12 @@ spec:
                 configMapKeyRef:
                   name: nacos-cm
                   key: mysql.password
+            - name: SPRING_DATASOURCE_PLATFORM
+              value: "mysql"
             - name: NACOS_SERVER_PORT
               value: "8848"
             - name: NACOS_APPLICATION_PORT
               value: "8848"
-
             - name: PREFER_HOST_MODE
               value: "hostname"
           volumeMounts:

--- a/deploy/nacos/nacos-pvc-nfs.yaml
+++ b/deploy/nacos/nacos-pvc-nfs.yaml
@@ -43,6 +43,7 @@ kind: StatefulSet
 metadata:
   name: nacos
 spec:
+  podManagementPolicy: Parallel
   serviceName: nacos-headless
   replicas: 3
   template:

--- a/deploy/nacos/nacos-pvc-nfs.yaml
+++ b/deploy/nacos/nacos-pvc-nfs.yaml
@@ -1,3 +1,5 @@
+# 请阅读Wiki文章
+# https://github.com/nacos-group/nacos-k8s/wiki/%E4%BD%BF%E7%94%A8peerfinder%E6%89%A9%E5%AE%B9%E6%8F%92%E4%BB%B6
 ---
 apiVersion: v1
 kind: Service
@@ -5,9 +7,8 @@ metadata:
   name: nacos-headless
   labels:
     app: nacos
-  annotations:
-    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
+  publishNotReadyAddresses: true 
   ports:
     - port: 8848
       name: server
@@ -31,6 +32,7 @@ kind: ConfigMap
 metadata:
   name: nacos-cm
 data:
+  mysql.host: "mysql"
   mysql.db.name: "nacos_devtest"
   mysql.port: "3306"
   mysql.user: "nacos"
@@ -98,6 +100,11 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: metadata.namespace
+            - name: MYSQL_SERVICE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: nacos-cm
+                  key: mysql.host
             - name: MYSQL_SERVICE_DB_NAME
               valueFrom:
                 configMapKeyRef:
@@ -118,6 +125,8 @@ spec:
                 configMapKeyRef:
                   name: nacos-cm
                   key: mysql.password
+            - name: SPRING_DATASOURCE_PLATFORM
+              value: "mysql"
             - name: NACOS_SERVER_PORT
               value: "8848"
             - name: NACOS_APPLICATION_PORT

--- a/deploy/nacos/nacos-quick-start.yaml
+++ b/deploy/nacos/nacos-quick-start.yaml
@@ -30,6 +30,7 @@ kind: ConfigMap
 metadata:
   name: nacos-cm
 data:
+  mysql.host: "mysql"
   mysql.db.name: "nacos_devtest"
   mysql.port: "3306"
   mysql.user: "nacos"
@@ -79,6 +80,11 @@ spec:
           env:
             - name: NACOS_REPLICAS
               value: "3"
+            - name: MYSQL_SERVICE_HOST
+              valueFrom:
+                configMapKeyRef:
+                  name: nacos-cm
+                  key: mysql.host
             - name: MYSQL_SERVICE_DB_NAME
               valueFrom:
                 configMapKeyRef:
@@ -99,6 +105,8 @@ spec:
                 configMapKeyRef:
                   name: nacos-cm
                   key: mysql.password
+            - name: SPRING_DATASOURCE_PLATFORM
+              value: "mysql"
             - name: NACOS_SERVER_PORT
               value: "8848"
             - name: NACOS_APPLICATION_PORT

--- a/deploy/nacos/nacos-quick-start.yaml
+++ b/deploy/nacos/nacos-quick-start.yaml
@@ -61,7 +61,7 @@ spec:
                       - nacos
               topologyKey: "kubernetes.io/hostname"
       containers:
-        - name: k8snacos
+        - name: nacos
           imagePullPolicy: Always
           image: nacos/nacos-server:latest
           resources:


### PR DESCRIPTION
在ConfigMap中添加mysql.host配置，并在StatefulSet中添加此环境变量;

添加SPRING_DATASOURCE_PLATFORM环境变量配置;

修改使用peer时的podManagementPolicy;

将Wiki中的k8s低版本的service.alpha.kubernetes.io/tolerate-unready-endpoints: "true" 注解升级到新版publishNotReadyAddresses: true 配置

添加SPRING_DATASOURCE_PLATFORM参数说明