### PR TITLE
cleanup: remove ioutil for new go version

### DIFF
--- a/operator/pkg/service/nacos/cluster.go
+++ b/operator/pkg/service/nacos/cluster.go
@@ -3,7 +3,7 @@ package nacosClient
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"strings"
@@ -57,7 +57,7 @@ func (c *NacosClient) GetClusterNodes(ip string) (ServersInfo, error) {
 		return servers, err
 	}
 	defer resp.Body.Close()
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return servers, err
 	}

--- a/operator/pkg/service/operator/Kind.go
+++ b/operator/pkg/service/operator/Kind.go
@@ -2,7 +2,7 @@ package operator
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	batchv1 "k8s.io/api/batch/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"nacos.io/nacos-operator/pkg/util/merge"
@@ -355,7 +355,7 @@ func (e *KindClient) buildJob(nacos *nacosgroupv1alpha1.Nacos) *batchv1.Job {
 func readSql(sqlFileName string) string {
 	// abspath：项目的根路径
 	abspath, _ := filepath.Abs("")
-	bytes, err := ioutil.ReadFile(abspath + "/config/sql/" + sqlFileName)
+	bytes, err := os.ReadFile(abspath + "/config/sql/" + sqlFileName)
 	if err != nil {
 		fmt.Printf("read sql file failed, err: %s", err.Error())
 		return ""


### PR DESCRIPTION
The `io/ioutil` has been deprecated from go version: https://go.dev/doc/go1.16#ioutil