### PR TITLE
Update nacos-no-pvc-ingress.yaml

### DIFF
--- a/deploy/nacos/nacos-no-pvc-ingress.yaml
+++ b/deploy/nacos/nacos-no-pvc-ingress.yaml
@@ -134,7 +134,8 @@ spec:
   - host: nacos-web.nacos-demo.com
     http:
       paths:
-      - path: /
+      - path: /nacos
+        pathType: Prefix
         backend:
           service: 
             name: nacos-headless


### PR DESCRIPTION
1、修改path配置为 /nacos ，避免配置ingress-nginx的跟代理与其他服务代理冲突 2、路由规则配置pathType，否则部署失败（1.22.1版本上发现）