### PR TITLE
解决nacos-server:v2.2.0镜像拉起后报错的现象

### DIFF
--- a/deploy/nacos/nacos-quick-start.yaml
+++ b/deploy/nacos/nacos-quick-start.yaml
@@ -80,6 +80,8 @@ spec:
           env:
             - name: NACOS_REPLICAS
               value: "3"
+            - name: SPRING_DATASOURCE_PLATFORM
+              value: "mysql"
             - name: MYSQL_SERVICE_HOST
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
在使用nacos-server:v2.2.0镜像后，K8S拉起后报错：
nacos server did not start because dumpservice bean construction failure. errMsg102, errllsg dataSource or tableName is null
这个patch解决了这个环境变量问题