### PR TITLE
修复2.2.x版本nacos 没有/nacos/v1/ns/operator/servers 接口的问题

### DIFF
--- a/operator/pkg/service/nacos/cluster.go
+++ b/operator/pkg/service/nacos/cluster.go
@@ -18,7 +18,9 @@ type NacosClient struct {
 }
 
 type ServersInfo struct {
-	Servers []struct {
+	Code    int         `json:"code"`
+	Message interface{} `json:"message"`
+	Data    []struct {
 		IP         string `json:"ip"`
 		Port       int    `json:"port"`
 		State      string `json:"state"`
@@ -38,7 +40,7 @@ type ServersInfo struct {
 		} `json:"extendInfo"`
 		Address       string `json:"address"`
 		FailAccessCnt int    `json:"failAccessCnt"`
-	} `json:"servers"`
+	} `json:"data"`
 }
 
 func (c *NacosClient) GetClusterNodes(ip string) (ServersInfo, error) {
@@ -48,9 +50,9 @@ func (c *NacosClient) GetClusterNodes(ip string) (ServersInfo, error) {
 	var err error
 
 	if strings.Contains(ip, ":") {
-		resp, err = c.httpClient.Get(fmt.Sprintf("http://[%s]:8848/nacos/v1/ns/operator/servers", ip))
+		resp, err = c.httpClient.Get(fmt.Sprintf("http://[%s]:8848/nacos/v1/core/cluster/nodes", ip))
 	} else {
-		resp, err = c.httpClient.Get(fmt.Sprintf("http://%s:8848/nacos/v1/ns/operator/servers", ip))
+		resp, err = c.httpClient.Get(fmt.Sprintf("http://%s:8848/nacos/v1/core/cluster/nodes", ip))
 	}
 
 	if err != nil {

--- a/operator/pkg/service/operator/Check.go
+++ b/operator/pkg/service/operator/Check.go
@@ -57,8 +57,8 @@ func (c *CheckClient) CheckNacos(nacos *nacosgroupv1alpha1.Nacos, pods []corev1.
 		servers, err := c.nacosClient.GetClusterNodes(pod.Status.PodIP)
 		myErrors.EnsureNormalMyError(err, myErrors.CODE_CLUSTER_FAILE)
 		// 确保cr中实例个数和server数量相同
-		myErrors.EnsureEqual(len(servers.Servers), int(*nacos.Spec.Replicas), myErrors.CODE_CLUSTER_FAILE, "server num is not equal")
-		for _, svc := range servers.Servers {
+		myErrors.EnsureEqual(len(servers.Data), int(*nacos.Spec.Replicas), myErrors.CODE_CLUSTER_FAILE, "server num is not equal")
+		for _, svc := range servers.Data {
 			myErrors.EnsureEqual(svc.State, "UP", myErrors.CODE_CLUSTER_FAILE, "node is not up")
 			if leader != "" {
 				// 确保每个节点leader相同


### PR DESCRIPTION
operator在check nacos状态的时候使用的是/nacos/v1/ns/operator/servers接口
但是在nacos 2.2.0版本的时候已经废弃这个接口了
所以改成/nacos/v1/core/cluster/nodes来check当前nacos的装备