### PR TITLE
hotfix：部署nacos-operator-all.yaml时operator提示 cannot get resource "leases" in API group "coordination.k8s.io"

### DIFF
--- a/operator/chart/nacos-operator/nacos-operator-all.yaml
+++ b/operator/chart/nacos-operator/nacos-operator-all.yaml
@@ -1281,6 +1281,14 @@ rules:
       - patch
       - list
       - watch
+  - apiGroups:
+      - coordination.k8s.io
+    resources:
+      - leases
+    verbs:
+      - get
+      - create
+      - update
 ---
 # Source: nacos-operator/templates/serviceaccount.yaml
 apiVersion: rbac.authorization.k8s.io/v1

--- a/operator/chart/nacos-operator/templates/serviceaccount.yaml
+++ b/operator/chart/nacos-operator/templates/serviceaccount.yaml
@@ -74,8 +74,5 @@ rules:
       - get
       - create
       - update
-      - patch
-      - list
-      - watch
 
 {{- end }}


### PR DESCRIPTION
1.修改使用kubectl apply -f nacos-operator-all.yaml方式部署时出现cannot get resou……rce "leases" in API group "coordination.k8s.io"

2.在nacos的clusterrole中给leases授予的verbs太多了，参考eck：https://www.elastic.co/guide/en/cloud-on-k8s/master/k8s-elastic-agent-fleet-quickstart.html和argo workflow https://github.com/argoproj/argo-workflows/blob/master/manifests/cluster-install/workflow-controller-rbac/workflow-controller-role.yaml。针对lease授予get、create和update