### PR TITLE
'Configuration via environment variables' key error modification

### DIFF
--- a/operator/README-CN.md
+++ b/operator/README-CN.md
@@ -202,7 +202,9 @@ spec:
     spec:
       type: standalone
       env:
-      - key: JVM_XMS
+      - name: JVM_XMS
+        value: 2g
+      - name: JVM_XMX
         value: 2g
     ```
 

--- a/operator/README.md
+++ b/operator/README.md
@@ -182,7 +182,9 @@ spec:
     spec:
       type: standalone
       env:
-      - key: JVM_XMS
+      - name: JVM_XMS
+        value: 2g
+      - name: JVM_XMX
         value: 2g
     ```
 


### PR DESCRIPTION
Modify the error tutorial in the documentation, the original env.key is changed to env.name