### PR TITLE
update doc that should support mysql.param

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -74,7 +74,7 @@ chmod +x quick-startup.sh
 
 ## 部署 NFS
 
-* 创建角色 
+* 创建角色
 
 ```shell
 kubectl create -f deploy/nfs/rbac.yaml
@@ -136,7 +136,7 @@ kubectl create -f deploy/mysql/mysql-nfs.yaml
 
 ```shell
 
-kubectl get pod 
+kubectl get pod
 NAME                         READY   STATUS    RESTARTS   AGE
 mysql-gf2vd                        1/1     Running   0          111m
 
@@ -160,6 +160,7 @@ data:
   mysql.port: "端口"
   mysql.user: "用户名"
   mysql.password: "密码"
+  mysql.param: "JDBC 连接参数"
 ```
 
 
@@ -282,6 +283,7 @@ for i in 0 1 2; do echo nacos-$i; kubectl exec nacos-$i curl GET "http://localho
 | mysql.port     | N       | 端口                        |
 | mysql.user     | Y       | 用户名                     |
 | mysql.password | Y       | 密码                     |
+| mysql.param | N       | JDBC 连接参数                   |
 | SPRING_DATASOURCE_PLATFORM | Y       | 数据库类型,默认embedded嵌入式数据库,参数只支持mysql或embedded                     |
 | NACOS_REPLICAS        | N      | 确定执行Nacos启动节点数量,如果不适用动态扩容插件,就必须配置这个属性，否则使用扩容插件后不会生效 |
 | NACOS_SERVER_PORT     | N       | Nacos 端口  为peer_finder插件提供端口          |
@@ -290,7 +292,7 @@ for i in 0 1 2; do echo nacos-$i; kubectl exec nacos-$i curl GET "http://localho
 
 
 
-* **nfs** deployment.yaml 
+* **nfs** deployment.yaml
 
 | 名称       | 必要 | 描述                     |
 | ---------- | -------- | ------------------------ |
@@ -301,7 +303,7 @@ for i in 0 1 2; do echo nacos-$i; kubectl exec nacos-$i curl GET "http://localho
 
 
 
-* mysql 
+* mysql
 
 | 名称                     | 必要 | 描述                                                      |
 | -------------------------- | -------- | ----------------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ If you use a custom database, please initialize the database script yourself fir
 
 ## Deploy NFS
 
-* Create Role 
+* Create Role
 
 ```shell
 kubectl create -f deploy/nfs/rbac.yaml
@@ -147,7 +147,7 @@ kubectl create -f deploy/mysql/mysql-nfs.yaml
 
 ```shell
 
-kubectl get pod 
+kubectl get pod
 NAME                         READY   STATUS    RESTARTS   AGE
 mysql-gf2vd                        1/1     Running   0          111m
 
@@ -155,7 +155,7 @@ mysql-gf2vd                        1/1     Running   0          111m
 
 
 
-## Deploy Nacos 
+## Deploy Nacos
 
 
 
@@ -170,6 +170,7 @@ data:
   mysql.port: " db port"
   mysql.user: " db username"
   mysql.password: " db password"
+  mysql.param: " db param"
 ```
 
 
@@ -247,13 +248,13 @@ You can find that the new node has joined the cluster
 - Kubernetes Node configuration(for reference only)
 
 | Hostname   | Configuration                                                                    |
-| ---------- | -------------------------------------------------------------------------------- |                    
+| ---------- | -------------------------------------------------------------------------------- |
 | k8s-master | CentOS Linux release 7.4.1708 (Core) Single-core processor Mem 4G Cloud disk 40G |
 | node01     | CentOS Linux release 7.4.1708 (Core) Single-core processor Mem 4G Cloud disk 40G |
 | node02     | CentOS Linux release 7.4.1708 (Core) Single-core processor Mem 4G Cloud disk 40G |
 
-- Kubernetes version：**1.12.2+** 
-- NFS version：**4.1+** 
+- Kubernetes version：**1.12.2+**
+- NFS version：**4.1+**
 
 
 
@@ -277,7 +278,7 @@ You can find that the new node has joined the cluster
 
 # Configuration properties
 
-* nacos-pvc-nfs.yaml or nacos-quick-start.yaml 
+* nacos-pvc-nfs.yaml or nacos-quick-start.yaml
 
 | Name                  | Required | Description                                    |
 | --------------------- | -------- | --------------------------------------- |
@@ -285,6 +286,7 @@ You can find that the new node has joined the cluster
 | mysql.port     | N       | database port                          |
 | mysql.user     | Y       | database username                        |
 | mysql.password | Y       | database password                       |
+| mysql.param | N       | database parameter                       |
 | SPRING_DATASOURCE_PLATFORM | Y       | Database type,The default is embedded database,parameters only support mysql or embedded                       |
 | NACOS_REPLICAS        | Y       | The number of clusters must be consistent with the value of the replicas attribute |
 | NACOS_SERVER_PORT     | N       | Nacos port,default:8848 for Peer-finder plugin               |
@@ -293,7 +295,7 @@ You can find that the new node has joined the cluster
 
 
 
-* **nfs** deployment.yaml 
+* **nfs** deployment.yaml
 
 | Name       | Required | Description                     |
 | ---------- | -------- | ------------------------ |
@@ -304,7 +306,7 @@ You can find that the new node has joined the cluster
 
 
 
-* mysql yaml 
+* mysql yaml
 
 | Name                       | Required | Description                                                        |
 | -------------------------- | -------- | ----------------------------------------------------------- |


### PR DESCRIPTION
我發現 nacos 的 k8s yaml template 有使用且支援 mysql.param, 如果是使用这个 template conifgmap 应该也可以使用 "mysql.param" 来调整 parameter.
 
```yaml
            - name: MYSQL_SERVICE_PASSWORD
              valueFrom:
                configMapKeyRef:
                  name: nacos-cm
                  key: mysql.password
            - name: MYSQL_SERVICE_DB_PARAM
              valueFrom:
                configMapKeyRef:
                  name: nacos-cm
                  key: mysql.param
 ```

https://github.com/nacos-group/nacos-k8s/blob/v1.0.0/helm/templates/statefulset.yaml#L134-L138
https://github.com/nacos-group/nacos-k8s/blob/v1.0.0/helm/templates/configmap.yaml