### PR TITLE
修改适配了nacos最新版本镜像，解决了sh无法处理shell脚本中数组的问题，同时解决了initScript中的语法错误，让nacos-…

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -24,7 +24,7 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build  -a -v
 
 # Use distroless as minimal base image to package the manager binary
 # Refer to https://github.com/GoogleContainerTools/distroless for more details
-FROM registry.cn-hangzhou.aliyuncs.com/shenkonghui/distroless-static:nonroot
+FROM gcr.io/distroless/static-debian12:nonroot
 WORKDIR /
 COPY --from=builder /workspace/manager .
 COPY --from=builder /workspace/config/sql/nacos-mysql.sql config/sql/nacos-mysql.sql

--- a/operator/pkg/service/operator/Kind.go
+++ b/operator/pkg/service/operator/Kind.go
@@ -33,7 +33,7 @@ const NEW_RAFT_PORT = 9848
 const SQL_FILE_NAME = "nacos-mysql.sql"
 
 var initScrit = `array=(%s)
-succ = 0
+succ=0
 
 for element in ${array[@]} 
 do
@@ -858,7 +858,7 @@ func (e *KindClient) buildStatefulsetCluster(nacos *nacosgroupv1alpha1.Nacos, ss
 	}
 	ss.Spec.Template.Spec.Containers[0].Env = append(ss.Spec.Template.Spec.Containers[0].Env, env...)
 	// 先检查域名解析再启动
-	ss.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", fmt.Sprintf("%s&&bin/docker-startup.sh", fmt.Sprintf(initScrit, serivceNoPort))}
+	ss.Spec.Template.Spec.Containers[0].Command = []string{"bash", "-c", fmt.Sprintf("%s&&bin/docker-startup.sh", fmt.Sprintf(initScrit, serivceNoPort))}
 	return ss
 }
 


### PR DESCRIPTION
Resolved an issue where sh command could not handle arrays in shell scripts and fixed syntax errors in initScript, enabling nacos-operator to support Nacos V3.