### PR TITLE
Codex/fix sh compatible startup

### DIFF
--- a/operator/Dockerfile
+++ b/operator/Dockerfile
@@ -17,7 +17,7 @@ COPY main.go main.go
 COPY api/ api/
 COPY controllers/ controllers/
 COPY pkg/ pkg/
-ADD https://raw.githubusercontent.com/alibaba/nacos/develop/distribution/conf/mysql-schema.sql config/sql/nacos-mysql.sql
+ADD https://raw.githubusercontent.com/alibaba/nacos/develop/plugin-default-impl/nacos-default-datasource-plugin/nacos-datasource-plugin-mysql/src/main/resources/META-INF/mysql-schema.sql config/sql/nacos-mysql.sql
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build  -a -v -o manager main.go

--- a/operator/pkg/service/operator/Kind.go
+++ b/operator/pkg/service/operator/Kind.go
@@ -32,19 +32,15 @@ const NEW_RAFT_PORT = 9848
 // 导入的sql文件名称
 const SQL_FILE_NAME = "nacos-mysql.sql"
 
-var initScrit = `array=(%s)
-succ = 0
-
-for element in ${array[@]} 
+var initScrit = `for element in %s
 do
   while true
   do
-    ping $element -c 1 > /dev/stdout
-    if [[ $? -eq 0 ]]; then
-      echo $element "all domain ready"
+    if ping "$element" -c 1 > /dev/stdout 2>&1; then
+      echo "$element all domain ready"
       break
     else
-      echo $element "wait for other domain ready"
+      echo "$element wait for other domain ready"
     fi
     sleep 1
   done
@@ -858,7 +854,7 @@ func (e *KindClient) buildStatefulsetCluster(nacos *nacosgroupv1alpha1.Nacos, ss
 	}
 	ss.Spec.Template.Spec.Containers[0].Env = append(ss.Spec.Template.Spec.Containers[0].Env, env...)
 	// 先检查域名解析再启动
-	ss.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", fmt.Sprintf("%s&&bin/docker-startup.sh", fmt.Sprintf(initScrit, serivceNoPort))}
+	ss.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", fmt.Sprintf("%s && exec bin/docker-startup.sh", fmt.Sprintf(initScrit, serivceNoPort))}
 	return ss
 }
 


### PR DESCRIPTION
## Summary

This PR includes two fixes for the operator:

1. Make the cluster startup pre-check script compatible with `sh`
2. Update the remote MySQL schema download URL in the operator Dockerfile

## Changes

### 1. Fix cluster startup script compatibility

The operator previously generated a startup command using `sh -c`, but the embedded script used bash-specific syntax such as:

- `array=(...)`
- `${array[@]}`
- `[[ ... ]]`

This could cause cluster pods to fail at startup with errors like:

```bash
sh: 1: Syntax error: "(" unexpected
