### PR TITLE
fix: change the execution of the MySQL initialization script to bash

### DIFF
--- a/quick-startup.sh
+++ b/quick-startup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 echo "mysql mysql startup"
-sh deploy/mysql/mysql-init.sh && kubectl create -f ./deploy/mysql/mysql-local.yaml
+bash deploy/mysql/mysql-init.sh && kubectl create -f ./deploy/mysql/mysql-local.yaml
 
 
 echo "nacos quick startup"


### PR DESCRIPTION
change the execution of the MySQL initialization script to bash, fixing the issue where the source command is not supported.

<img width="424" height="38" alt="image" src="https://github.com/user-attachments/assets/3baebf60-2445-4a00-b21c-b695ad542651" />
