### PR TITLE
feat(helm): support both Nacos 2.x and 3.x deployment

### DIFF
--- a/hack/ci/values-nacos-2x.yaml
+++ b/hack/ci/values-nacos-2x.yaml
@@ -1,19 +1,5 @@
 # Helm values override for Nacos 2.x CI smoke tests.
 # image.tag is injected by helm-smoke-test.sh via --set.
-#
-# Known limitations for Nacos 2.x on the current Helm chart:
-# 1. Probe paths are hardcoded to /v3/console/health/* (3.x endpoints).
-#    Until the chart supports configurable probes, 2.x pods will fail readiness.
-# 2. The chart always renders consolePort and mcpPort as container ports.
-#    These must differ from serverPort (8848) to avoid duplicate port errors.
-#    We use placeholder ports that Nacos 2.x will simply ignore.
-nacos:
-  consolePort: 8080
-  mcpPort: 9080
-  authToken: bmFjb3MtY2ktc21va2UtdGVzdC1zZWNyZXQta2V5LWZvci1qd3QtdG9rZW4=
-  identityKey: nacosKey
-  identityValue: nacosValue
-
 service:
   type: ClusterIP
 

--- a/hack/ci/values-nacos-3x.yaml
+++ b/hack/ci/values-nacos-3x.yaml
@@ -1,12 +1,5 @@
 # Helm values override for Nacos 3.x CI smoke tests.
 # image.tag is injected by helm-smoke-test.sh via --set.
-nacos:
-  consolePort: 8080
-  mcpPort: 9080
-  authToken: bmFjb3MtY2ktc21va2UtdGVzdC1zZWNyZXQta2V5LWZvci1qd3QtdG9rZW4=
-  identityKey: nacosKey
-  identityValue: nacosValue
-
 service:
   type: ClusterIP
 

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "3.0.1"
+appVersion: "3.2.3"
 description: A Helm chart for Kubernetes
 name: nacos
 version: 1.0.0

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -43,3 +43,21 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Detect whether the Nacos image is v3.x.
+Override with nacos.majorVersion if using a custom tag like "latest".
+Returns the string "true" or "false".
+*/}}
+{{- define "nacos.isV3" -}}
+{{- $tag := .Values.nacos.image.tag | toString -}}
+{{- if .Values.nacos.majorVersion -}}
+  {{- eq (.Values.nacos.majorVersion | toString) "3" -}}
+{{- else if hasPrefix "v2." $tag -}}
+  {{- false -}}
+{{- else if hasPrefix "2." $tag -}}
+  {{- false -}}
+{{- else -}}
+  {{- true -}}
+{{- end -}}
+{{- end -}}

--- a/helm/templates/service.yaml
+++ b/helm/templates/service.yaml
@@ -1,4 +1,4 @@
-{{- if and (eq .Values.global.mode "cluster") }}
+{{- if eq .Values.global.mode "cluster" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -12,19 +12,21 @@ spec:
       targetPort: {{ .Values.nacos.serverPort }}
       protocol: TCP
       name: http
-    - port: {{ add .Values.service.port 1000}}
+    - port: {{ add .Values.service.port 1000 }}
       name: client-rpc
-      targetPort: {{add .Values.nacos.serverPort 1000}}
-    - port: {{add .Values.service.port 1001}}
+      targetPort: {{ add .Values.nacos.serverPort 1000 }}
+    - port: {{ add .Values.service.port 1001 }}
       name: raft-rpc
-      targetPort: {{add .Values.nacos.serverPort 1001}}
-    - port: {{ .Values.nacos.consolePort}}
+      targetPort: {{ add .Values.nacos.serverPort 1001 }}
+    {{- if eq (include "nacos.isV3" .) "true" }}
+    - port: {{ .Values.nacos.consolePort }}
       name: console
       targetPort: {{ .Values.nacos.consolePort }}
-    - port: {{ .Values.nacos.mcpPort}}
+    - port: {{ .Values.nacos.mcpPort }}
       name: mcp
       targetPort: {{ .Values.nacos.mcpPort }}
-    ## 兼容1.4.x版本的选举端口
+    {{- end }}
+    ## compat: 1.4.x raft election port
     - port: 7848
       name: old-raft-rpc
       targetPort: 7848
@@ -32,17 +34,21 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "nacos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-  {{- end }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Service
 metadata:
   name: nacos-cs
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.service.labels }}
   labels:
-  {{- toYaml .Values.service.labels | nindent 4 }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.service.annotations }}
   annotations:
-  {{- toYaml .Values.service.annotations | nindent 4 }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:
@@ -50,26 +56,28 @@ spec:
       targetPort: {{ .Values.nacos.serverPort }}
       protocol: TCP
       name: http
-    - port: {{ add .Values.service.port 1000}}
+      {{- if eq .Values.service.type "NodePort" }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
+    - port: {{ add .Values.service.port 1000 }}
       name: client-rpc
-      targetPort: {{add .Values.nacos.serverPort 1000}}
-    - port: {{add .Values.service.port 1001}}
+      targetPort: {{ add .Values.nacos.serverPort 1000 }}
+    - port: {{ add .Values.service.port 1001 }}
       name: raft-rpc
-      targetPort: {{add .Values.nacos.serverPort 1001}}
-    - port: 8080
+      targetPort: {{ add .Values.nacos.serverPort 1001 }}
+    {{- if eq (include "nacos.isV3" .) "true" }}
+    - port: {{ .Values.nacos.consolePort }}
       name: console
       targetPort: {{ .Values.nacos.consolePort }}
-    - port: 9080
+    - port: {{ .Values.nacos.mcpPort }}
       name: mcp
       targetPort: {{ .Values.nacos.mcpPort }}
-    ## 兼容1.4.x版本的选举端口
+    {{- end }}
+    ## compat: 1.4.x raft election port
     - port: 7848
       name: old-raft-rpc
       targetPort: 7848
       protocol: TCP
-      {{- if eq .Values.service.type "NodePort" }}
-      nodePort: {{ .Values.service.nodePort }}
-  {{- end }}
   selector:
     app.kubernetes.io/name: {{ include "nacos.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -39,6 +39,10 @@ spec:
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if and (eq .Values.global.mode "cluster") (.Values.nacos.plugin.enable) }}
       initContainers:
         - name: peer-finder-plugin-install
@@ -54,36 +58,60 @@ spec:
           image: "{{ .Values.nacos.image.repository }}:{{ .Values.nacos.image.tag }}"
           imagePullPolicy: {{ .Values.nacos.image.pullPolicy }}
           startupProbe:
-            initialDelaySeconds: 180
+            initialDelaySeconds: {{ .Values.nacos.probe.startupDelaySeconds | default 180 }}
             periodSeconds: 5
             timeoutSeconds: 10
             httpGet:
               scheme: HTTP
+              {{- if eq (include "nacos.isV3" .) "true" }}
               port: {{ .Values.nacos.consolePort }}
               path: /v3/console/health/readiness
+              {{- else }}
+              port: {{ .Values.nacos.serverPort }}
+              path: /nacos/
+              {{- end }}
           livenessProbe:
             initialDelaySeconds: 10
             periodSeconds: 5
             timeoutSeconds: 10
             httpGet:
               scheme: HTTP
+              {{- if eq (include "nacos.isV3" .) "true" }}
               port: {{ .Values.nacos.consolePort }}
               path: /v3/console/health/liveness
+              {{- else }}
+              port: {{ .Values.nacos.serverPort }}
+              path: /nacos/
+              {{- end }}
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 10
+            httpGet:
+              scheme: HTTP
+              {{- if eq (include "nacos.isV3" .) "true" }}
+              port: {{ .Values.nacos.consolePort }}
+              path: /v3/console/health/readiness
+              {{- else }}
+              port: {{ .Values.nacos.serverPort }}
+              path: /nacos/
+              {{- end }}
           ports:
             - name: client-http
               containerPort: {{ .Values.nacos.serverPort }}
               protocol: TCP
-            - containerPort: {{ add .Values.nacos.serverPort 1000}}
+            - containerPort: {{ add .Values.nacos.serverPort 1000 }}
               name: client-rpc
             - containerPort: {{ add .Values.nacos.serverPort 1001 }}
               name: raft-rpc
             - containerPort: 7848
               name: old-raft-rpc
-            - containerPort: {{ .Values.nacos.consolePort}}
+            {{- if eq (include "nacos.isV3" .) "true" }}
+            - containerPort: {{ .Values.nacos.consolePort }}
               name: console
               protocol: TCP
             - containerPort: {{ .Values.nacos.mcpPort }}
               name: mcp
+            {{- end }}
           resources:
           {{ toYaml .Values.resources | nindent 12 }}
           env:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+imagePullSecrets: []
+# - name: my-registry-secret
+
 global:
   mode: standalone
 #  deploymentType: merge
@@ -12,8 +15,10 @@ global:
 nacos:
   image:
     repository: nacos/nacos-server
-    tag: v3.0.1
+    tag: v3.2.3
     pullPolicy: IfNotPresent
+  # majorVersion: ""  # Override version detection when using custom tags like "latest".
+                       # Set to "2" for Nacos 2.x or "3" for Nacos 3.x.
   plugin:
     enable: true
     image:
@@ -27,9 +32,12 @@ nacos:
   serverPort: 8848
   consolePort: 8080
   mcpPort: 9080
-  authToken: nil
-  identityKey: nil
-  identityValue: nil
+  # IMPORTANT: Change this token in production! Must be a base64-encoded string >= 32 bytes.
+  authToken: VGhpc0lzQ3VzdG9tU2VjcmV0S2V5MEluSXRzVmVyeVNhZmU=
+  identityKey: serverIdentity
+  identityValue: security
+  probe:
+    startupDelaySeconds: 180
   health:
     enabled: false
   storage:
@@ -42,6 +50,8 @@ nacos:
 #      username: usernmae
 #      password: password
 #      param: characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useSSL=false
+#      # For MySQL 8.0+, you may need to add: &allowPublicKeyRetrieval=true
+#      # Full example: characterEncoding=utf8&connectTimeout=1000&socketTimeout=3000&autoReconnect=true&useSSL=false&allowPublicKeyRetrieval=true
 
 persistence:
   enabled: false


### PR DESCRIPTION
## Summary

- Auto-detect Nacos major version from image tag with `nacos.isV3` helper
- Version-aware probes: 3.x → `/v3/console/health/*` on 8080, 2.x → `/nacos/` on 8848
- Add missing readinessProbe
- Conditional console/MCP port rendering (3.x only)
- Add imagePullSecrets support (#477)
- Fix auth defaults to prevent startup crash (#496 #497)
- Add MySQL 8.0+ JDBC param documentation (#515)
- Fix hardcoded console port and nodePort placement in nacos-cs service

Closes #522
Fixes #488
Ref #502 #515 #477 #496 #497

## Test plan

- [ ] CI 3.x standalone (embedded + mysql) × 2 K8s versions pass
- [ ] CI 3.x cluster × 2 K8s versions pass
- [ ] CI 2.x standalone (embedded + mysql) × 2 K8s versions pass
- [ ] CI 2.x cluster × 2 K8s versions pass
- [ ] `helm template` renders correctly for both 2.x and 3.x