### PR TITLE
refactor(deploy): modernize quick-start and no-pvc-ingress YAMLs

### DIFF
--- a/deploy/mysql/mysql-local.yaml
+++ b/deploy/mysql/mysql-local.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: apps/v1
+kind: Deployment
 metadata:
   name: mysql
   labels:
@@ -7,7 +7,8 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: mysql
+    matchLabels:
+      name: mysql
   template:
     metadata:
       labels:

--- a/deploy/nacos/nacos-no-pvc-ingress.yaml
+++ b/deploy/nacos/nacos-no-pvc-ingress.yaml
@@ -1,4 +1,3 @@
-###使用自建数据库；使用Ingress发布配置后台###
 ---
 apiVersion: v1
 kind: Service
@@ -19,10 +18,13 @@ spec:
     - port: 9849
       name: raft-rpc
       targetPort: 9849
-      ## 兼容1.4.x版本的选举端口
+    ## compat: 1.4.x raft election port
     - port: 7848
       name: old-raft-rpc
       targetPort: 7848
+    - port: 8080
+      name: console
+      targetPort: 8080
   selector:
     app: nacos
 ---
@@ -44,12 +46,13 @@ metadata:
 spec:
   serviceName: nacos-headless
   replicas: 3
+  selector:
+    matchLabels:
+      app: nacos
   template:
     metadata:
       labels:
         app: nacos
-      annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
     spec:
       affinity:
         podAntiAffinity:
@@ -63,12 +66,35 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
         - name: nacos
-          imagePullPolicy: Always
-          image: nacos/nacos-server:latest
+          imagePullPolicy: IfNotPresent
+          image: nacos/nacos-server:v3.2.3
           resources:
             requests:
               memory: "2Gi"
               cpu: "500m"
+          startupProbe:
+            initialDelaySeconds: 180
+            periodSeconds: 5
+            timeoutSeconds: 10
+            httpGet:
+              scheme: HTTP
+              port: 8080
+              path: /v3/console/health/readiness
+          livenessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 10
+            httpGet:
+              scheme: HTTP
+              port: 8080
+              path: /v3/console/health/liveness
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 10
+            httpGet:
+              scheme: HTTP
+              port: 8080
+              path: /v3/console/health/readiness
           ports:
             - containerPort: 8848
               name: client
@@ -78,6 +104,8 @@ spec:
               name: raft-rpc
             - containerPort: 7848
               name: old-raft-rpc
+            - containerPort: 8080
+              name: console
           env:
             - name: NACOS_REPLICAS
               value: "3"
@@ -114,17 +142,15 @@ spec:
               value: "8848"
             - name: PREFER_HOST_MODE
               value: "hostname"
+            - name: NACOS_AUTH_TOKEN
+              value: "VGhpc0lzQ3VzdG9tU2VjcmV0S2V5MEluSXRzVmVyeVNhZmU="
+            - name: NACOS_AUTH_IDENTITY_KEY
+              value: "serverIdentity"
+            - name: NACOS_AUTH_IDENTITY_VALUE
+              value: "security"
             - name: NACOS_SERVERS
               value: "nacos-0.nacos-headless.default.svc.cluster.local:8848 nacos-1.nacos-headless.default.svc.cluster.local:8848 nacos-2.nacos-headless.default.svc.cluster.local:8848"
-  selector:
-    matchLabels:
-      app: nacos
-
-
-
-
 ---
-# ------------------- App Ingress ------------------- #
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -134,10 +160,10 @@ spec:
   - host: nacos-web.nacos-demo.com
     http:
       paths:
-      - path: /nacos
+      - path: /
         pathType: Prefix
         backend:
-          service: 
+          service:
             name: nacos-headless
             port:
-              name: server
+              name: console

--- a/deploy/nacos/nacos-quick-start.yaml
+++ b/deploy/nacos/nacos-quick-start.yaml
@@ -18,7 +18,7 @@ spec:
     - port: 9849
       name: raft-rpc
       targetPort: 9849
-    ## 兼容1.4.x版本的选举端口
+    ## compat: 1.4.x raft election port
     - port: 7848
       name: old-raft-rpc
       targetPort: 7848
@@ -46,12 +46,13 @@ metadata:
 spec:
   serviceName: nacos-headless
   replicas: 3
+  selector:
+    matchLabels:
+      app: nacos
   template:
     metadata:
       labels:
         app: nacos
-      annotations:
-        pod.alpha.kubernetes.io/initialized: "true"
     spec:
       affinity:
         podAntiAffinity:
@@ -65,12 +66,35 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
         - name: nacos
-          imagePullPolicy: Always
-          image: nacos/nacos-server:latest
+          imagePullPolicy: IfNotPresent
+          image: nacos/nacos-server:v3.2.3
           resources:
             requests:
               memory: "2Gi"
               cpu: "500m"
+          startupProbe:
+            initialDelaySeconds: 180
+            periodSeconds: 5
+            timeoutSeconds: 10
+            httpGet:
+              scheme: HTTP
+              port: 8080
+              path: /v3/console/health/readiness
+          livenessProbe:
+            initialDelaySeconds: 10
+            periodSeconds: 5
+            timeoutSeconds: 10
+            httpGet:
+              scheme: HTTP
+              port: 8080
+              path: /v3/console/health/liveness
+          readinessProbe:
+            periodSeconds: 5
+            timeoutSeconds: 10
+            httpGet:
+              scheme: HTTP
+              port: 8080
+              path: /v3/console/health/readiness
           ports:
             - containerPort: 8848
               name: client
@@ -118,8 +142,11 @@ spec:
               value: "8848"
             - name: PREFER_HOST_MODE
               value: "hostname"
+            - name: NACOS_AUTH_TOKEN
+              value: "VGhpc0lzQ3VzdG9tU2VjcmV0S2V5MEluSXRzVmVyeVNhZmU="
+            - name: NACOS_AUTH_IDENTITY_KEY
+              value: "serverIdentity"
+            - name: NACOS_AUTH_IDENTITY_VALUE
+              value: "security"
             - name: NACOS_SERVERS
               value: "nacos-0.nacos-headless.default.svc.cluster.local:8848 nacos-1.nacos-headless.default.svc.cluster.local:8848 nacos-2.nacos-headless.default.svc.cluster.local:8848"
-  selector:
-    matchLabels:
-      app: nacos


### PR DESCRIPTION
## Summary

Modernize the plain YAML deployment files (quick-start and no-pvc-ingress):

- `deploy/mysql/mysql-local.yaml`: `ReplicationController` → `Deployment`
- `deploy/nacos/nacos-quick-start.yaml` and `deploy/nacos/nacos-no-pvc-ingress.yaml`:
  - Pin image to `nacos/nacos-server:v3.2.3` (was `latest`)
  - Add startup/liveness/readiness probes for Nacos 3.x
  - Add auth env vars (`NACOS_AUTH_TOKEN`, `NACOS_AUTH_IDENTITY_KEY/VALUE`) to prevent startup crash
  - Add console port 8080 to no-pvc-ingress headless service
  - Remove deprecated `pod.alpha.kubernetes.io/initialized` annotation
  - Change `imagePullPolicy` from `Always` to `IfNotPresent`
  - Ingress: route to console port 8080 instead of server port 8848

## Test plan

- [ ] CI passes
- [ ] `kubectl apply -f deploy/mysql/mysql-local.yaml` creates a Deployment (not RC)
- [ ] YAML files pass validation