### PR TITLE
feat(helm): preserve Nacos auth default semantics

### DIFF
--- a/.github/workflows/ci-helm-smoke-test.yaml
+++ b/.github/workflows/ci-helm-smoke-test.yaml
@@ -7,6 +7,21 @@ on:
     branches: [master]
 
 jobs:
+  helm-auth-render-test:
+    name: Helm auth render test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: latest
+
+      - name: Verify auth values, Secret references, and rendered environment
+        run: ./hack/ci/helm-auth-render-test.sh
+
   helm-smoke-test:
     name: "${{ matrix.mode }} | nacos ${{ matrix.nacos-version }} | k8s ${{ matrix.k8s-version }}"
     runs-on: ubuntu-latest
@@ -81,6 +96,73 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: diagnostics-${{ matrix.nacos-version }}-${{ matrix.k8s-version }}-${{ matrix.mode }}
+          path: /tmp/diagnostics/
+          retention-days: 7
+
+      - name: Cleanup
+        if: always()
+        run: kind delete cluster --name ci
+
+  helm-auth-runtime-test:
+    # Add an AUTH_MODE=unset case after a Nacos 3.3+ image is published. It
+    # should expect Client API authentication to be enabled by image default.
+    name: "auth ${{ matrix.auth-mode }} | nacos v3.2.4 | k8s v1.34.8"
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        auth-mode: [true, false]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Kind
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          kind version
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: latest
+
+      - name: Create Kind cluster
+        run: |
+          kind create cluster --name ci --image kindest/node:v1.34.8
+          kubectl cluster-info
+
+      - name: Pre-pull Nacos image
+        run: |
+          docker pull nacos/nacos-server:v3.2.4
+          kind load docker-image nacos/nacos-server:v3.2.4 --name ci
+
+      - name: Run authentication behavior test
+        run: |
+          NACOS_VERSION=v3.2.4 \
+          MODE=standalone \
+          STORAGE=embedded \
+          AUTH_MODE=${{ matrix.auth-mode }} \
+            ./hack/ci/helm-smoke-test.sh
+
+      - name: Collect diagnostics
+        if: failure()
+        run: |
+          mkdir -p /tmp/diagnostics
+          kubectl get pods -o wide > /tmp/diagnostics/pods.txt 2>&1 || true
+          kubectl describe pods -l app.kubernetes.io/name=nacos > /tmp/diagnostics/describe.txt 2>&1 || true
+          for pod in $(kubectl get pods -l app.kubernetes.io/name=nacos -o name 2>/dev/null); do
+            pod_name="${pod#pod/}"
+            kubectl logs "${pod}" --all-containers > "/tmp/diagnostics/logs-${pod_name}.txt" 2>&1 || true
+          done
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: diagnostics-auth-${{ matrix.auth-mode }}
           path: /tmp/diagnostics/
           retention-days: 7
 

--- a/hack/ci/helm-auth-render-test.sh
+++ b/hack/ci/helm-auth-render-test.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# Helm render tests for the Nacos authentication contract.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+HELM_CHART="${REPO_ROOT}/helm"
+HELM_BIN="${HELM_BIN:-helm}"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "${TEST_DIR}"' EXIT
+
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+render() {
+  local name=$1
+  shift
+  "${HELM_BIN}" template "${name}" "${HELM_CHART}" "$@" > "${TEST_DIR}/${name}.yaml"
+}
+
+count_matching_lines() {
+  local pattern=$1
+  local file=$2
+  grep -Ec "${pattern}" "${file}" || true
+}
+
+assert_count() {
+  local expected=$1
+  local pattern=$2
+  local file=$3
+  local actual
+  actual=$(count_matching_lines "${pattern}" "${file}")
+  if [[ "${actual}" != "${expected}" ]]; then
+    fail "expected ${expected} line(s) matching '${pattern}' in ${file}, got ${actual}"
+  fi
+}
+
+assert_auth_value() {
+  local expected=$1
+  local file=$2
+  if ! awk -v expected="${expected}" '
+    /^[[:space:]]*- name: NACOS_AUTH_ENABLE$/ {
+      getline
+      if ($0 ~ "value: \\\"" expected "\\\"") {
+        matches++
+      }
+    }
+    END { exit matches == 1 ? 0 : 1 }
+  ' "${file}"; then
+    fail "NACOS_AUTH_ENABLE=${expected} was not rendered exactly once in ${file}"
+  fi
+}
+
+extract_secret_data() {
+  local key=$1
+  local file=$2
+  awk -v key="${key}:" '
+    /^data:$/ { in_data=1; next }
+    in_data && $1 == key {
+      gsub(/"/, "", $2)
+      print $2
+      exit
+    }
+  ' "${file}"
+}
+
+"${HELM_BIN}" lint "${HELM_CHART}"
+
+render auth-unset
+render auth-true --set nacos.auth.enabled=true --set global.mode=cluster
+render auth-false --set nacos.auth.enabled=false --set nacos.storage.type=mysql
+render auth-existing-secret \
+  --set nacos.auth.existingSecret=user-managed-auth \
+  --set nacos.auth.tokenSecretKey=custom-token \
+  --set nacos.auth.identityKeySecretKey=custom-identity-key \
+  --set nacos.auth.identityValueSecretKey=custom-identity-value
+legacy_token='VGhpc0lzQ3VzdG9tU2VjcmV0S2V5MEluSXRzVmVyeVNhZmU='
+render auth-legacy-inline \
+  --set-string "nacos.authToken=${legacy_token}" \
+  --set-string nacos.identityKey=legacy-key \
+  --set-string nacos.identityValue=legacy-value
+
+assert_count 0 '^[[:space:]]*- name: NACOS_AUTH_ENABLE$' "${TEST_DIR}/auth-unset.yaml"
+assert_count 1 '^[[:space:]]*- name: NACOS_AUTH_ENABLE$' "${TEST_DIR}/auth-true.yaml"
+assert_count 1 '^[[:space:]]*- name: NACOS_AUTH_ENABLE$' "${TEST_DIR}/auth-false.yaml"
+assert_auth_value true "${TEST_DIR}/auth-true.yaml"
+assert_auth_value false "${TEST_DIR}/auth-false.yaml"
+
+for file in auth-unset auth-true auth-false auth-existing-secret auth-legacy-inline; do
+  assert_count 1 '^[[:space:]]*- name: NACOS_AUTH_TOKEN$' "${TEST_DIR}/${file}.yaml"
+  assert_count 1 '^[[:space:]]*- name: NACOS_AUTH_IDENTITY_KEY$' "${TEST_DIR}/${file}.yaml"
+  assert_count 1 '^[[:space:]]*- name: NACOS_AUTH_IDENTITY_VALUE$' "${TEST_DIR}/${file}.yaml"
+done
+
+assert_count 1 '^kind: Secret$' "${TEST_DIR}/auth-unset.yaml"
+assert_count 0 '^kind: Secret$' "${TEST_DIR}/auth-existing-secret.yaml"
+assert_count 3 '^[[:space:]]*name: user-managed-auth$' "${TEST_DIR}/auth-existing-secret.yaml"
+assert_count 1 '^[[:space:]]*key: "custom-token"$' "${TEST_DIR}/auth-existing-secret.yaml"
+assert_count 1 '^[[:space:]]*key: "custom-identity-key"$' "${TEST_DIR}/auth-existing-secret.yaml"
+assert_count 1 '^[[:space:]]*key: "custom-identity-value"$' "${TEST_DIR}/auth-existing-secret.yaml"
+
+legacy_token_data=$(extract_secret_data token "${TEST_DIR}/auth-legacy-inline.yaml")
+legacy_identity_key_data=$(extract_secret_data identity-key "${TEST_DIR}/auth-legacy-inline.yaml")
+legacy_identity_value_data=$(extract_secret_data identity-value "${TEST_DIR}/auth-legacy-inline.yaml")
+[[ "$(printf '%s' "${legacy_token_data}" | openssl base64 -d -A)" == "${legacy_token}" ]] \
+  || fail "legacy inline authToken changed when moved into Secret data"
+[[ "$(printf '%s' "${legacy_identity_key_data}" | openssl base64 -d -A)" == "legacy-key" ]] \
+  || fail "legacy inline identityKey changed when moved into Secret data"
+[[ "$(printf '%s' "${legacy_identity_value_data}" | openssl base64 -d -A)" == "legacy-value" ]] \
+  || fail "legacy inline identityValue changed when moved into Secret data"
+
+token_data=$(extract_secret_data token "${TEST_DIR}/auth-unset.yaml")
+[[ -n "${token_data}" ]] || fail "generated token Secret data is empty"
+token_value=$(printf '%s' "${token_data}" | openssl base64 -d -A)
+decoded_token_length=$(printf '%s' "${token_value}" | openssl base64 -d -A | wc -c | tr -d ' ')
+if [[ "${decoded_token_length}" -lt 32 ]]; then
+  fail "generated Nacos token decodes to fewer than 32 bytes"
+fi
+
+if "${HELM_BIN}" template invalid "${HELM_CHART}" \
+  --set-string nacos.auth.enabled=invalid >/dev/null 2>&1; then
+  fail "nacos.auth.enabled accepted a non-boolean, non-null value"
+fi
+
+echo "Helm authentication render tests passed."

--- a/hack/ci/helm-smoke-test.sh
+++ b/hack/ci/helm-smoke-test.sh
@@ -7,6 +7,7 @@
 #   MODE           - standalone or cluster
 # Optional:
 #   STORAGE        - embedded (default) or mysql
+#   AUTH_MODE      - unset (default), true, or false
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -15,15 +16,42 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 : "${NACOS_VERSION:?NACOS_VERSION is required}"
 : "${MODE:?MODE is required (standalone or cluster)}"
 : "${STORAGE:=embedded}"
+: "${AUTH_MODE:=unset}"
+
+case "${AUTH_MODE}" in
+  unset|true|false) ;;
+  *)
+    echo "ERROR: AUTH_MODE must be unset, true, or false"
+    exit 1
+    ;;
+esac
 
 RELEASE_NAME="nacos-ci"
 NAMESPACE="default"
 HELM_CHART="${REPO_ROOT}/helm"
+HELM_BIN="${HELM_BIN:-helm}"
+AUTH_TEST_DIR="$(mktemp -d)"
+CLIENT_PORT_FORWARD_PID=""
 if [[ "${MODE}" == "cluster" ]]; then
   TIMEOUT="600s"
 else
   TIMEOUT="300s"
 fi
+
+cleanup_client_port_forward() {
+  if [[ -n "${CLIENT_PORT_FORWARD_PID}" ]]; then
+    kill "${CLIENT_PORT_FORWARD_PID}" 2>/dev/null || true
+    wait "${CLIENT_PORT_FORWARD_PID}" 2>/dev/null || true
+    CLIENT_PORT_FORWARD_PID=""
+  fi
+}
+
+cleanup_local_files() {
+  cleanup_client_port_forward
+  rm -rf "${AUTH_TEST_DIR}"
+}
+
+trap cleanup_local_files EXIT
 
 # Determine major version (2 or 3) from tag like v2.5.3 or v3.2.3
 MAJOR_VERSION="${NACOS_VERSION#v}"
@@ -46,6 +74,7 @@ echo "=== Helm Smoke Test ==="
 echo "  Nacos version : ${NACOS_VERSION} (${MAJOR_VERSION}.x)"
 echo "  Mode          : ${MODE}"
 echo "  Storage       : ${STORAGE}"
+echo "  Auth mode     : ${AUTH_MODE}"
 echo "  Values file   : ${VALUES_FILE}"
 echo "  Health check  : :${HEALTH_PORT}${HEALTH_PATH}"
 echo ""
@@ -106,6 +135,10 @@ helm_install() {
   extra_args+=(--set "nacos.image.tag=${NACOS_VERSION}")
   extra_args+=(--set "global.mode=${MODE}")
 
+  if [[ "${AUTH_MODE}" != "unset" ]]; then
+    extra_args+=(--set "nacos.auth.enabled=${AUTH_MODE}")
+  fi
+
   if [[ "${MODE}" == "cluster" ]]; then
     extra_args+=(--set "nacos.replicaCount=3")
     extra_args+=(--set "nacos.probe.startupDelaySeconds=180")
@@ -123,9 +156,100 @@ helm_install() {
 
   echo ">>> Installing Helm chart..."
   echo "    helm install ${RELEASE_NAME} ${HELM_CHART} -f ${VALUES_FILE} ${extra_args[*]}"
-  helm install "${RELEASE_NAME}" "${HELM_CHART}" \
+  "${HELM_BIN}" install "${RELEASE_NAME}" "${HELM_CHART}" \
     -f "${VALUES_FILE}" \
     "${extra_args[@]}"
+}
+
+# --- Authentication deployment contract ---
+auth_secret_name() {
+  local statefulset=$1
+  kubectl get statefulset "${statefulset}" \
+    -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="NACOS_AUTH_TOKEN")].valueFrom.secretKeyRef.name}'
+}
+
+auth_secret_payload() {
+  local secret_name=$1
+  local key
+  for key in token identity-key identity-value; do
+    kubectl get secret "${secret_name}" -o "jsonpath={.data['${key}']}"
+    printf '\n'
+  done
+}
+
+verify_auth_deployment() {
+  echo ">>> Verifying authentication deployment contract..."
+
+  local statefulset="${RELEASE_NAME}"
+
+  local rendered_auth_value
+  rendered_auth_value=$(kubectl get statefulset "${statefulset}" \
+    -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="NACOS_AUTH_ENABLE")].value}')
+  if [[ "${AUTH_MODE}" == "unset" && -n "${rendered_auth_value}" ]]; then
+    echo "ERROR: unset auth mode rendered NACOS_AUTH_ENABLE=${rendered_auth_value}"
+    return 1
+  fi
+  if [[ "${AUTH_MODE}" != "unset" && "${rendered_auth_value}" != "${AUTH_MODE}" ]]; then
+    echo "ERROR: expected NACOS_AUTH_ENABLE=${AUTH_MODE}, got ${rendered_auth_value:-<unset>}"
+    return 1
+  fi
+
+  local secret_name
+  secret_name=$(auth_secret_name "${statefulset}")
+  if [[ -z "${secret_name}" ]]; then
+    echo "ERROR: NACOS_AUTH_TOKEN does not reference a Secret"
+    return 1
+  fi
+  local key
+  for key in token identity-key identity-value; do
+    if [[ -z "$(kubectl get secret "${secret_name}" -o "jsonpath={.data['${key}']}")" ]]; then
+      echo "ERROR: ${secret_name} does not contain non-empty ${key} data"
+      return 1
+    fi
+  done
+
+  echo ">>> Authentication environment and Secret references are valid."
+}
+
+verify_auth_secret_stability() {
+  echo ">>> Verifying generated credentials remain stable across a no-op upgrade..."
+
+  local statefulset="${RELEASE_NAME}"
+  local secret_name
+  secret_name=$(auth_secret_name "${statefulset}")
+  local secret_before
+  local checksum_before
+  local revision_before
+  secret_before=$(auth_secret_payload "${secret_name}")
+  checksum_before=$(kubectl get statefulset "${statefulset}" \
+    -o go-template='{{ index .spec.template.metadata.annotations "checksum/auth-config" }}')
+  revision_before=$(kubectl get statefulset "${statefulset}" -o jsonpath='{.status.currentRevision}')
+
+  "${HELM_BIN}" upgrade "${RELEASE_NAME}" "${HELM_CHART}" --reuse-values \
+    --wait --timeout="${TIMEOUT}"
+
+  local secret_after
+  local checksum_after
+  local revision_after
+  secret_after=$(auth_secret_payload "${secret_name}")
+  checksum_after=$(kubectl get statefulset "${statefulset}" \
+    -o go-template='{{ index .spec.template.metadata.annotations "checksum/auth-config" }}')
+  revision_after=$(kubectl get statefulset "${statefulset}" -o jsonpath='{.status.currentRevision}')
+
+  if [[ "${secret_before}" != "${secret_after}" ]]; then
+    echo "ERROR: generated authentication credentials changed during a no-op upgrade"
+    return 1
+  fi
+  if [[ "${checksum_before}" != "${checksum_after}" ]]; then
+    echo "ERROR: auth checksum changed during a no-op upgrade"
+    return 1
+  fi
+  if [[ "${revision_before}" != "${revision_after}" ]]; then
+    echo "ERROR: StatefulSet rolled during a no-op auth upgrade"
+    return 1
+  fi
+
+  echo ">>> Authentication credentials and StatefulSet revision remained stable."
 }
 
 # --- Wait for pods ---
@@ -188,6 +312,164 @@ smoke_verify() {
   fi
 }
 
+expected_client_auth_state() {
+  if [[ "${AUTH_MODE}" == "true" ]]; then
+    echo enabled
+  else
+    echo disabled
+  fi
+}
+
+request_code() {
+  local output_file=$1
+  shift
+  curl -sS -o "${output_file}" -w '%{http_code}' "$@" || true
+}
+
+verify_v3_auth_behavior() {
+  if [[ "${MAJOR_VERSION}" != "3" || "${AUTH_MODE}" == "unset" ]]; then
+    return
+  fi
+
+  echo ">>> Verifying Client, Admin, and Console authentication behavior..."
+  local expected_state
+  expected_state=$(expected_client_auth_state)
+  local pod
+  pod=$(kubectl get pods -l app.kubernetes.io/name=nacos -o jsonpath='{.items[0].metadata.name}')
+
+  kubectl port-forward "${pod}" 18848:8848 18080:8080 \
+    > "${AUTH_TEST_DIR}/port-forward.log" 2>&1 &
+  CLIENT_PORT_FORWARD_PID=$!
+  local retries=0
+  until curl -sS -o /dev/null "http://127.0.0.1:18848/nacos/"; do
+    retries=$((retries + 1))
+    if [[ "${retries}" -ge 30 ]]; then
+      echo "ERROR: Client port-forward did not become ready"
+      return 1
+    fi
+    sleep 1
+  done
+
+  local login_code
+  local attempt
+  local admin_setup_code
+  admin_setup_code=$(request_code "${AUTH_TEST_DIR}/admin-setup.json" -X POST \
+    "http://127.0.0.1:18848/nacos/v3/auth/user/admin" \
+    --data-urlencode 'password=nacos')
+  if [[ "${admin_setup_code}" != "200" ]]; then
+    echo "ERROR: administrator initialization returned HTTP ${admin_setup_code}"
+    return 1
+  fi
+  local admin_result_code
+  admin_result_code=$(python3 -c \
+    'import json,sys; print(json.load(sys.stdin).get("code", ""))' \
+    < "${AUTH_TEST_DIR}/admin-setup.json")
+  if [[ "${admin_result_code}" != "0" && "${admin_result_code}" != "409" ]]; then
+    echo "ERROR: administrator initialization returned code ${admin_result_code:-<missing>}"
+    return 1
+  fi
+
+  login_code=""
+  for attempt in {1..30}; do
+    login_code=$(request_code "${AUTH_TEST_DIR}/login.json" -X POST \
+      "http://127.0.0.1:18848/nacos/v3/auth/user/login" \
+      --data-urlencode 'username=nacos' --data-urlencode 'password=nacos')
+    if [[ "${login_code}" == "200" ]]; then
+      break
+    fi
+    sleep 1
+  done
+  if [[ "${login_code}" != "200" ]]; then
+    echo "ERROR: administrator login returned HTTP ${login_code}"
+    return 1
+  fi
+
+  local access_token
+  access_token=$(python3 -c \
+    'import json,sys; value=json.load(sys.stdin); print(value.get("accessToken", ""))' \
+    < "${AUTH_TEST_DIR}/login.json")
+  if [[ -z "${access_token}" ]]; then
+    echo "ERROR: administrator login did not return accessToken"
+    return 1
+  fi
+
+  local data_id="helm-auth-${AUTH_MODE}-${MODE}-${STORAGE}"
+  local content="authenticated-${AUTH_MODE}"
+  local publish_code
+  publish_code=$(request_code "${AUTH_TEST_DIR}/publish.json" -X POST \
+    "http://127.0.0.1:18848/nacos/v3/admin/cs/config" \
+    -H "accessToken: ${access_token}" \
+    --data-urlencode "dataId=${data_id}" \
+    --data-urlencode 'groupName=DEFAULT_GROUP' \
+    --data-urlencode "content=${content}")
+  if [[ "${publish_code}" != "200" ]]; then
+    echo "ERROR: authenticated config publish returned HTTP ${publish_code}"
+    return 1
+  fi
+
+  local authorized_code
+  authorized_code=""
+  for attempt in {1..30}; do
+    authorized_code=$(request_code "${AUTH_TEST_DIR}/authorized-client.json" -G \
+      "http://127.0.0.1:18848/nacos/v3/client/cs/config" \
+      -H "accessToken: ${access_token}" \
+      --data-urlencode "dataId=${data_id}" \
+      --data-urlencode 'groupName=DEFAULT_GROUP')
+    if [[ "${authorized_code}" == "200" ]] \
+      && grep -Fq "${content}" "${AUTH_TEST_DIR}/authorized-client.json"; then
+      break
+    fi
+    sleep 1
+  done
+  if [[ "${authorized_code}" != "200" ]] \
+    || ! grep -Fq "${content}" "${AUTH_TEST_DIR}/authorized-client.json"; then
+    echo "ERROR: authenticated Client API request did not return the published content"
+    return 1
+  fi
+
+  local anonymous_client_code
+  anonymous_client_code=$(request_code "${AUTH_TEST_DIR}/anonymous-client.json" -G \
+    "http://127.0.0.1:18848/nacos/v3/client/cs/config" \
+    --data-urlencode "dataId=${data_id}" \
+    --data-urlencode 'groupName=DEFAULT_GROUP')
+  if [[ "${expected_state}" == "enabled" && "${anonymous_client_code}" != "403" ]]; then
+    echo "ERROR: anonymous Client API returned HTTP ${anonymous_client_code}; expected 403"
+    return 1
+  fi
+  if [[ "${expected_state}" == "disabled" && "${anonymous_client_code}" != "200" ]]; then
+    echo "ERROR: anonymous Client API returned HTTP ${anonymous_client_code}; expected 200"
+    return 1
+  fi
+  if [[ "${expected_state}" == "disabled" ]] \
+    && ! grep -Fq "${content}" "${AUTH_TEST_DIR}/anonymous-client.json"; then
+    echo "ERROR: anonymous Client API did not return the published content"
+    return 1
+  fi
+
+  local anonymous_admin_code
+  anonymous_admin_code=$(request_code "${AUTH_TEST_DIR}/anonymous-admin.json" -G \
+    "http://127.0.0.1:18848/nacos/v3/admin/cs/config/list" \
+    --data-urlencode 'namespaceId=public' \
+    --data-urlencode 'pageNo=1' \
+    --data-urlencode 'pageSize=10')
+  if [[ "${anonymous_admin_code}" != "403" ]]; then
+    echo "ERROR: anonymous Admin API returned HTTP ${anonymous_admin_code}; expected 403"
+    return 1
+  fi
+
+  local anonymous_console_code
+  anonymous_console_code=$(request_code "${AUTH_TEST_DIR}/anonymous-console.json" -G \
+    "http://127.0.0.1:18080/v3/console/core/namespace" \
+    --data-urlencode 'namespaceId=public')
+  if [[ "${anonymous_console_code}" != "403" ]]; then
+    echo "ERROR: anonymous Console API returned HTTP ${anonymous_console_code}; expected 403"
+    return 1
+  fi
+
+  cleanup_client_port_forward
+  echo ">>> Authentication behavior is valid (${expected_state})."
+}
+
 # --- Diagnostics (called on failure) ---
 collect_diagnostics() {
   local diag_dir="${DIAGNOSTICS_DIR:-/tmp/diagnostics}"
@@ -215,13 +497,16 @@ fi
 
 helm_install
 wait_for_pods
+verify_auth_deployment
+verify_auth_secret_stability
 smoke_verify
+verify_v3_auth_behavior
 
 echo ""
 echo "=== PASSED: ${MODE} / ${STORAGE} / ${NACOS_VERSION} ==="
 
 # Cleanup for next round (when running multiple storage types)
-helm uninstall "${RELEASE_NAME}" --wait 2>/dev/null || true
+"${HELM_BIN}" uninstall "${RELEASE_NAME}" --wait 2>/dev/null || true
 if [[ "${STORAGE}" == "mysql" ]]; then
   cleanup_mysql
 fi

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 appVersion: "3.2.3"
 description: A Helm chart for Kubernetes
 name: nacos
-version: 1.0.0
+version: 1.1.0
 maintainers:
   - name: arrowfeng
   - name: paderlol

--- a/helm/README.md
+++ b/helm/README.md
@@ -22,29 +22,58 @@ If you use a custom database, please initialize the database script yourself fir
 To install the chart with `release name`:
 
 ```shell
-$ helm install `release name` ./ --set nacos.authToken="{base64 string}",nacos.identityKey={key},nacos.identityValue={value}
+$ kubectl create secret generic nacos-auth \
+    --from-literal=token="${NACOS_AUTH_TOKEN}" \
+    --from-literal=identity-key="${NACOS_AUTH_IDENTITY_KEY}" \
+    --from-literal=identity-value="${NACOS_AUTH_IDENTITY_VALUE}"
+$ helm install `release name` ./ --set nacos.auth.existingSecret=nacos-auth
 ```
 
-The command deploys Nacos on the Kubernetes cluster in the default configuration. It will run without a mysql chart and persistent volume. The [configuration](#configuration) section lists the parameters that can be configured during installation. 
+The command deploys Nacos on the Kubernetes cluster in the default configuration. It will run without a mysql chart and persistent volume. The [configuration](#configuration) section lists the parameters that can be configured during installation.
+
+When `nacos.auth.existingSecret` is empty, the chart creates a release-scoped Secret with generated credentials and reuses those values on subsequent Helm upgrades. Supplying an existing Secret is recommended for production so that credentials can be managed and backed up independently.
+
+When upgrading from chart `1.0.0` or earlier, use `--reuse-values` for the first upgrade if the release still relies on the legacy inline `nacos.authToken`, `nacos.identityKey`, and `nacos.identityValue` values. The chart copies those retained values into its managed Secret. Alternatively, create an external Secret first and set `nacos.auth.existingSecret` during the upgrade.
+
+The chart does not set `NACOS_AUTH_ENABLE` unless `nacos.auth.enabled` is explicitly `true` or `false`. Therefore, an unset value inherits the selected image's behavior: Nacos 3.3 and later enable Client API authentication by default, while earlier images keep their own defaults.
+
+To keep Client API authentication disabled temporarily while upgrading existing clients to Nacos 3.3, set an explicit override:
+
+```shell
+$ helm upgrade `release name` ./ --reuse-values --set nacos.auth.enabled=false
+```
+
+This switch controls only Client API authentication. Admin and Console API authentication remain independent, and the authentication Secret is still mounted when Client API authentication is disabled.
 
 ### Service & Configuration Management
 
+Log in first and copy `accessToken` from the response when Client API authentication is enabled:
+
+```shell
+curl -X POST 'http://$NODE_IP:$NODE_PORT/nacos/v3/auth/user/login' \
+  -d 'username=nacos' -d "password=${NACOS_PASSWORD}"
+```
+
 #### Service registration
 ```shell
-curl -X POST 'http://$NODE_IP:$NODE_PORT/nacos/v2/ns/instance?serviceName=nacos.naming.serviceName&ip=20.18.7.10&port=8080'
+curl -X POST 'http://$NODE_IP:$NODE_PORT/nacos/v3/client/ns/instance?serviceName=nacos.naming.serviceName&ip=20.18.7.10&port=8080' \
+  -H "accessToken: ${NACOS_ACCESS_TOKEN}"
 ```
 
 #### Service discovery
 ```shell
-curl -X GET 'http://$NODE_IP:$NODE_PORT/nacos/v2/ns/instance/list?serviceName=nacos.naming.serviceName'
+curl -X GET 'http://$NODE_IP:$NODE_PORT/nacos/v3/client/ns/instance/list?serviceName=nacos.naming.serviceName' \
+  -H "accessToken: ${NACOS_ACCESS_TOKEN}"
 ```
 #### Publish config
 ```shell
-curl -X POST "http://$NODE_IP:$NODE_PORT/nacos/v2/cs/config?dataId=nacos.cfg.dataId&group=test&content=helloWorld"
+curl -X POST "http://$NODE_IP:$NODE_PORT/nacos/v3/admin/cs/config?dataId=nacos.cfg.dataId&groupName=test&content=helloWorld" \
+  -H "accessToken: ${NACOS_ACCESS_TOKEN}"
 ```
 #### Get config
 ```shell
-curl -X GET "http://$NODE_IP:$NODE_PORT/nacos/v2/cs/config?dataId=nacos.cfg.dataId&group=test"
+curl -X GET "http://$NODE_IP:$NODE_PORT/nacos/v3/client/cs/config?dataId=nacos.cfg.dataId&groupName=test" \
+  -H "accessToken: ${NACOS_ACCESS_TOKEN}"
 ```
 
 
@@ -85,9 +114,14 @@ The following table lists the configurable parameters of the Nacos chart and the
 | `nacos.serverPort`                              | Nacos pod's port                                                                                           | `8848`                                                                                          |
 | `nacos.consolePort`                             | Nacos console main port                                                                                    | `8080`                                                                                          |
 | `nacos.mcpPort`                                 | Nacos mcp registry port                                                                                    | `9080`                                                                                          |
-| `nacos.authToken`                               | Nacos auth plugin token secret key                                                                         | *Must* be setting manually                                                                      |
-| `nacos.identityKey`                             | Nacos auth server identity key                                                                             | *Must* be setting manually                                                                      |
-| `nacos.identityValue`                           | Nacos auth server identity value                                                                           | *Must* be setting manually                                                                      |
+| `nacos.auth.enabled`                            | Client API authentication override; `null` inherits the image default                                      | `null`                                                                                          |
+| `nacos.auth.existingSecret`                     | Existing Secret containing the token and server identity; generated when empty                             |                                                                                                 |
+| `nacos.auth.tokenSecretKey`                     | Key containing the Base64-encoded Nacos token secret                                                       | `token`                                                                                         |
+| `nacos.auth.identityKeySecretKey`               | Key containing the Nacos server identity key                                                               | `identity-key`                                                                                  |
+| `nacos.auth.identityValueSecretKey`             | Key containing the Nacos server identity value                                                             | `identity-value`                                                                                |
+| `nacos.authToken`                               | Deprecated inline token value; prefer `nacos.auth.existingSecret`                                          |                                                                                                 |
+| `nacos.identityKey`                             | Deprecated inline server identity key; prefer `nacos.auth.existingSecret`                                  |                                                                                                 |
+| `nacos.identityValue`                           | Deprecated inline server identity value; prefer `nacos.auth.existingSecret`                                |                                                                                                 |
 | `nacos.storage.type`                            | Nacos data storage method `mysql` or `embedded`. The `embedded` supports either standalone or cluster mode | `embedded`                                                                                      |
 | `nacos.storage.db.host`                         | mysql  host                                                                                                |                                                                                                 |
 | `nacos.storage.db.name`                         | mysql  database name                                                                                       |                                                                                                 |

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -32,6 +32,32 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Return the Secret containing the Nacos token and server identity.
+*/}}
+{{- define "nacos.auth.secretName" -}}
+{{- $auth := default (dict) .Values.nacos.auth -}}
+{{- $existingSecret := default "" (get $auth "existingSecret") -}}
+{{- if $existingSecret -}}
+{{- $existingSecret -}}
+{{- else -}}
+{{- printf "%s-auth" (include "nacos.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Hash auth-related values that require a StatefulSet rollout when changed.
+*/}}
+{{- define "nacos.auth.configChecksum" -}}
+{{- $auth := default (dict) .Values.nacos.auth -}}
+{{- $config := dict
+    "auth" $auth
+    "authToken" .Values.nacos.authToken
+    "identityKey" .Values.nacos.identityKey
+    "identityValue" .Values.nacos.identityValue -}}
+{{- $config | toJson | sha256sum -}}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "nacos.labels" -}}

--- a/helm/templates/secret.yaml
+++ b/helm/templates/secret.yaml
@@ -1,0 +1,45 @@
+{{- $auth := default (dict) .Values.nacos.auth -}}
+{{- $existingSecretName := default "" (get $auth "existingSecret") -}}
+{{- if not $existingSecretName }}
+{{- $secretName := include "nacos.auth.secretName" . -}}
+{{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName -}}
+{{- $tokenKey := default "token" (get $auth "tokenSecretKey") -}}
+{{- $identityKeyKey := default "identity-key" (get $auth "identityKeySecretKey") -}}
+{{- $identityValueKey := default "identity-value" (get $auth "identityValueSecretKey") -}}
+{{- $tokenData := "" -}}
+{{- if .Values.nacos.authToken -}}
+{{- $tokenData = (.Values.nacos.authToken | b64enc) -}}
+{{- else if and $existingSecret (hasKey $existingSecret.data $tokenKey) -}}
+{{- $tokenData = (index $existingSecret.data $tokenKey) -}}
+{{- else -}}
+{{- $tokenData = (randAlphaNum 64 | b64enc | b64enc) -}}
+{{- end -}}
+{{- $identityKeyData := "" -}}
+{{- if .Values.nacos.identityKey -}}
+{{- $identityKeyData = (.Values.nacos.identityKey | b64enc) -}}
+{{- else if and $existingSecret (hasKey $existingSecret.data $identityKeyKey) -}}
+{{- $identityKeyData = (index $existingSecret.data $identityKeyKey) -}}
+{{- else -}}
+{{- $identityKeyData = (randAlphaNum 32 | b64enc) -}}
+{{- end -}}
+{{- $identityValueData := "" -}}
+{{- if .Values.nacos.identityValue -}}
+{{- $identityValueData = (.Values.nacos.identityValue | b64enc) -}}
+{{- else if and $existingSecret (hasKey $existingSecret.data $identityValueKey) -}}
+{{- $identityValueData = (index $existingSecret.data $identityValueKey) -}}
+{{- else -}}
+{{- $identityValueData = (randAlphaNum 32 | b64enc) -}}
+{{- end -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $secretName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "nacos.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{ $tokenKey }}: {{ $tokenData | quote }}
+  {{ $identityKeyKey }}: {{ $identityKeyData | quote }}
+  {{ $identityValueKey }}: {{ $identityValueData | quote }}
+{{- end }}

--- a/helm/templates/statefulset.yaml
+++ b/helm/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- $auth := default (dict) .Values.nacos.auth -}}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -26,6 +27,8 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "nacos.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
+      annotations:
+        checksum/auth-config: {{ include "nacos.auth.configChecksum" . | quote }}
     spec:
       {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -121,12 +124,25 @@ spec:
               value: {{ .Values.nacos.serverPort | quote }}
             - name: PREFER_HOST_MODE
               value: {{ .Values.nacos.preferHostMode | quote }}
+            {{- if kindIs "bool" (get $auth "enabled") }}
+            - name: NACOS_AUTH_ENABLE
+              value: {{ get $auth "enabled" | quote }}
+            {{- end }}
             - name: NACOS_AUTH_TOKEN
-              value: {{ .Values.nacos.authToken | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nacos.auth.secretName" . }}
+                  key: {{ default "token" (get $auth "tokenSecretKey") | quote }}
             - name: NACOS_AUTH_IDENTITY_KEY
-              value: {{ .Values.nacos.identityKey | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nacos.auth.secretName" . }}
+                  key: {{ default "identity-key" (get $auth "identityKeySecretKey") | quote }}
             - name: NACOS_AUTH_IDENTITY_VALUE
-              value: {{ .Values.nacos.identityValue | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nacos.auth.secretName" . }}
+                  key: {{ default "identity-value" (get $auth "identityValueSecretKey") | quote }}
             {{- if eq .Values.global.mode "standalone" }}
             - name: MODE
               value: "standalone"
@@ -201,4 +217,3 @@ spec:
       spec:
   {{- toYaml .Values.persistence.data | nindent 8 }}
   {{- end }}
-

--- a/helm/values.schema.json
+++ b/helm/values.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "nacos": {
+      "type": "object",
+      "properties": {
+        "auth": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": [
+                "boolean",
+                "null"
+              ],
+              "description": "null inherits the Nacos image default; true and false are explicit overrides"
+            },
+            "existingSecret": {
+              "type": "string"
+            },
+            "tokenSecretKey": {
+              "type": "string",
+              "minLength": 1
+            },
+            "identityKeySecretKey": {
+              "type": "string",
+              "minLength": 1
+            },
+            "identityValueSecretKey": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "authToken": {
+          "type": "string"
+        },
+        "identityKey": {
+          "type": "string"
+        },
+        "identityValue": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -32,10 +32,20 @@ nacos:
   serverPort: 8848
   consolePort: 8080
   mcpPort: 9080
-  # IMPORTANT: Change this token in production! Must be a base64-encoded string >= 32 bytes.
-  authToken: VGhpc0lzQ3VzdG9tU2VjcmV0S2V5MEluSXRzVmVyeVNhZmU=
-  identityKey: serverIdentity
-  identityValue: security
+  auth:
+    # null inherits the image default. true and false are rendered explicitly.
+    enabled: null
+    # Use an existing Secret in production. When empty, the chart creates one
+    # and reuses its generated values during Helm upgrades.
+    existingSecret: ""
+    tokenSecretKey: token
+    identityKeySecretKey: identity-key
+    identityValueSecretKey: identity-value
+  # Deprecated inline credential values. Prefer nacos.auth.existingSecret.
+  # authToken must be a Base64-encoded value whose decoded form is at least 32 bytes.
+  authToken: ""
+  identityKey: ""
+  identityValue: ""
   probe:
     startupDelaySeconds: 180
   health:
@@ -109,6 +119,5 @@ nodeSelector: { }
 tolerations: [ ]
 
 affinity: { }
-
 
 


### PR DESCRIPTION
## What changed

- add `nacos.auth.enabled` as a tri-state override: `null` inherits the image default, while `true` and `false` are rendered explicitly
- move token and server identity values to a stable, release-scoped Secret, with support for a user-managed Secret and custom key names
- retain the legacy inline values for upgrade compatibility and document the first-upgrade procedure
- add schema validation plus render and Kind runtime coverage for enabled/disabled authentication behavior

## Compatibility

This lets Nacos 3.3+ inherit its default Client API authentication behavior without forcing an environment override. Existing installations can retain an explicit `false`. Admin and Console authentication remain independent.

For chart 1.0.0 and earlier, the first upgrade can use `--reuse-values` to copy retained inline credentials into the managed Secret, or set `nacos.auth.existingSecret`.

A published Nacos 3.3 image is not available yet, so CI covers image-default inheritance structurally and tests explicit `true`/`false` against v3.2.4. The workflow includes a release-gate note to add the 3.3 unset runtime case once that image exists.

## Verification

- Helm strict lint and auth render matrix
- schema rejection for invalid auth values
- local Kind v1.34.8 with Nacos v3.2.4: unset, explicit true, and explicit false
- authenticated Config publish/read plus anonymous Client/Admin/Console checks
- generated Secret and StatefulSet revision stability across no-op upgrade
- chart 1.0.0 to this chart with `--reuse-values`, preserving legacy token and identity values

Related to alibaba/nacos#15357.
Supersedes #475.